### PR TITLE
Restore classic cards and add pond view

### DIFF
--- a/assets/js/app-collection.js
+++ b/assets/js/app-collection.js
@@ -1,7 +1,7 @@
 // assets/js/app-collection.js
 // "My Frogs (Owned)" — restore mini header (Owned • Staked • Unclaimed Rewards)
 // Approve shows only when needed; Claim Rewards action; cards unchanged;
-// Meta shows "Staked Xd ago • Owned by You". Owned=Reservoir, Staked=controller.
+// Meta shows "Owned by You" / "Staked NNd ago by You". Owned=Reservoir, Staked=controller.
 
 (function(){
   'use strict';
@@ -174,9 +174,9 @@
     return rows.length? '<ul class="attr-list">'+rows.join('')+'</ul>' : '';
   }
   function metaLine(it){
-    if (!it.staked) return 'Not staked • Owned by You';
+    if (!it.staked) return 'Owned by You';
     var days = it.stakedTs ? timeAgoDays(it.stakedTs) : null;
-    return days!=null ? ('Staked '+days+'d ago • Owned by You') : 'Staked • Owned by You';
+    return days!=null ? ('Staked '+days+'d ago by You') : 'Staked by You';
   }
 
   function headerRoot(){

--- a/assets/js/frog-renderer.js
+++ b/assets/js/frog-renderer.js
@@ -19,7 +19,7 @@
   function metaURL(id){ return `${ROOT}/frog/json/${id}.json`; }
   function basePNG(id){ return `${ROOT}/frog/${id}.png`; }
   function layerPNG(k,v){ return `${ROOT}/frog/build_files/${k}/${v}.png`; }
-  function layerGIF(k,v){ return `${ROOT}/frog/build_files/${k}/${v}_animation.gif`; }
+  function layerGIF(k,v){ return `${ROOT}/frog/build_files/${k}/animations/${v}_animation.gif`; }
 
   const JSON_CACHE = new Map(); // id -> Promise(json|null)
 
@@ -70,10 +70,75 @@
       overflow: 'hidden',
       imageRendering: 'pixelated',
       backgroundRepeat: 'no-repeat',
-      backgroundPosition: '100% 100%', // bottom-right
-      backgroundSize: '10000% 10000%'  // zoom to 1px corner color
+      // Zoom way into the bottom-right of the original PNG so only the
+      // backdrop color is visible behind the layered attributes.
+      backgroundPosition: '140% 140%',
+      backgroundSize: '800% 800%'
     });
     return host;
+  }
+
+  const BACKDROP_COLOR_CACHE = new Map();
+  function applyBackdrop(host, tokenId){
+    if (!host) return;
+    if (!tokenId){
+      host.style.backgroundImage = 'none';
+      host.style.backgroundColor = 'transparent';
+      return;
+    }
+
+    const url = basePNG(tokenId);
+    host.style.backgroundImage = `url("${url}")`;
+
+    if (BACKDROP_COLOR_CACHE.has(tokenId)){
+      host.style.backgroundColor = BACKDROP_COLOR_CACHE.get(tokenId);
+      return;
+    }
+
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = function(){
+      try {
+        const w = img.naturalWidth || img.width || 1;
+        const h = img.naturalHeight || img.height || 1;
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) throw new Error('no ctx');
+        ctx.drawImage(img, 0, 0, w, h);
+        const data = ctx.getImageData(Math.max(0, w - 1), Math.max(0, h - 1), 1, 1).data;
+        const color = `rgba(${data[0]}, ${data[1]}, ${data[2]}, ${data[3] / 255})`;
+        BACKDROP_COLOR_CACHE.set(tokenId, color);
+        host.style.backgroundColor = color;
+      } catch(_){
+        BACKDROP_COLOR_CACHE.set(tokenId, 'transparent');
+      }
+    };
+    img.onerror = function(){ BACKDROP_COLOR_CACHE.set(tokenId, 'transparent'); };
+    img.src = url;
+  }
+
+  const ANIM_CACHE = new Map();
+  function hasAnimation(k,v){
+    const key = `${k}::${v}`;
+    if (ANIM_CACHE.has(key)) {
+      const cached = ANIM_CACHE.get(key);
+      if (typeof cached === 'boolean') return Promise.resolve(cached);
+      return cached;
+    }
+    const url = layerGIF(k,v);
+    const probe = new Promise(resolve => {
+      const img = new Image();
+      img.onload = () => resolve(true);
+      img.onerror = () => resolve(false);
+      img.src = url;
+    }).then(result => {
+      ANIM_CACHE.set(key, result);
+      return result;
+    });
+    ANIM_CACHE.set(key, probe);
+    return probe;
   }
 
   function addLayer(host, url, lift){
@@ -93,13 +158,15 @@
     host.appendChild(img);
   }
 
-  function addAnim(host, url){
+  function addAnim(host, url, lift){
     const img = document.createElement('img');
     img.src = url;
     img.alt = '';
     Object.assign(img.style, {
       position:'absolute', left:0, top:0, width:'100%', height:'100%',
-      imageRendering:'pixelated', pointerEvents:'none'
+      imageRendering:'pixelated', pointerEvents:'none',
+      transform: lift ? 'translate(-2px,-2px)' : 'none',
+      filter: lift ? 'drop-shadow(0 0 2px rgba(255,255,255,.15))' : 'none'
     });
     img.className = 'frog-anim';
     img.onerror = () => img.remove();
@@ -116,7 +183,7 @@
     const host = ensureHost(canvasEl, size);
 
     // Background from the original PNG (zoom bottom-right pixel)
-    host.style.backgroundImage = tokenId ? `url("${basePNG(tokenId)}")` : 'none';
+    applyBackdrop(host, tokenId);
 
     // Metadata
     let meta = metaOrNull;
@@ -125,16 +192,21 @@
     const attrs = attrsInOrder(meta);
     if (!attrs.length) throw new Error('no attributes');
 
-    // Static layers in EXACT metadata order
-    for (const a of attrs){
-      const lift = !!hoverKey && a.key === hoverKey && !DISALLOW_HOVER.has(a.key);
-      addLayer(host, layerPNG(a.key, a.value), lift);
-    }
+    const animFlags = await Promise.all(attrs.map(a => {
+      if (!a || DISALLOW_ANIM.has(a.key)) return Promise.resolve(false);
+      return hasAnimation(a.key, a.value).catch(() => false);
+    }));
 
-    // Animated overlays (skip Frog/Hat)
-    for (const a of attrs){
-      if (DISALLOW_ANIM.has(a.key)) continue;
-      addAnim(host, layerGIF(a.key, a.value));
+    // Render each layer exactly in metadata order, swapping to animations when available
+    for (let i=0;i<attrs.length;i++){
+      const a = attrs[i];
+      if (!a) continue;
+      const lift = !!hoverKey && a.key === hoverKey && !DISALLOW_HOVER.has(a.key);
+      if (animFlags[i] && !DISALLOW_ANIM.has(a.key)){
+        addAnim(host, layerGIF(a.key, a.value), lift);
+      } else {
+        addLayer(host, layerPNG(a.key, a.value), lift);
+      }
     }
   };
 

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -90,12 +90,16 @@
     function setState({ staked, owner }){
       current.staked = !!staked; current.owner = owner || '';
       // default line, then override below
-      fmLine && (fmLine.textContent = `${staked ? 'Staked' : 'Not staked'} • Owned by ${ownerLabel(owner)}`);
+      if (fmLine){
+        fmLine.textContent = staked
+          ? `Staked by ${ownerLabel(owner)}`
+          : `Owned by ${ownerLabel(owner)}`;
+      }
 
-      // If staked and we know when, render 'Staked NNd ago • Owned by ...'
+      // If staked and we know when, render 'Staked … ago by …'
       if (staked && current?.sinceMs && !isNaN(current.sinceMs)){
         const days = Math.floor((Date.now() - Number(current.sinceMs)) / 86400000);
-        fmLine && (fmLine.textContent = `Staked ${days}d ago • Owned by ${ownerLabel(owner)}`);
+        fmLine && (fmLine.textContent = `Staked ${days}d ago by ${ownerLabel(owner)}`);
       }
 
       fmOwner && (fmOwner.textContent = owner || '—');
@@ -118,7 +122,7 @@
       if (!current.staked || !fmLine) return;
 
       if (current.sinceMs && !isNaN(current.sinceMs)){
-        fmLine.textContent = `Staked ${fmtAgoMs(Date.now() - Number(current.sinceMs))} • Owned by ${ownerLabel(owner)}`;
+        fmLine.textContent = `Staked ${fmtAgoMs(Date.now() - Number(current.sinceMs))} by ${ownerLabel(owner)}`;
         return;
       }
 
@@ -135,12 +139,12 @@
           }
           if (ms){
             current.sinceMs = ms;
-            fmLine.textContent = `Staked ${fmtAgoMs(Date.now() - ms)} • Owned by ${ownerLabel(owner)}`;
+            fmLine.textContent = `Staked ${fmtAgoMs(Date.now() - ms)} by ${ownerLabel(owner)}`;
             return;
           }
         }
       }catch{}
-      fmLine.textContent = `Staked • Owned by ${ownerLabel(owner)}`;
+      fmLine.textContent = `Staked by ${ownerLabel(owner)}`;
     }
 
     // ---------- metadata/attributes ----------

--- a/assets/js/mutate.js
+++ b/assets/js/mutate.js
@@ -39,7 +39,10 @@
 
   function setInfo(id, data) {
     els.title.textContent = `Frog #${id}`;
-    els.status.textContent = `${data.staked ? 'Staked' : 'Not staked'} • ${data.ownerYou ? 'Owned by You' : 'Owner ' + short(data.owner)}`;
+    const ownerLabel = data.ownerYou ? 'You' : (data.owner ? short(data.owner) : '—');
+    els.status.textContent = data.staked
+      ? `Staked by ${ownerLabel}`
+      : `Owned by ${ownerLabel}`;
 
     // Traits list
     els.traits.innerHTML = '';

--- a/assets/js/owned-panel.js
+++ b/assets/js/owned-panel.js
@@ -384,10 +384,10 @@
       const attrs = Array.isArray(j?.attributes)
         ? j.attributes.map(a=>({ key:a?.key||a?.trait_type||'', value:(a?.value ?? a?.trait_value ?? '') }))
         : [];
-      const out = { id, attrs };
+      const out = { id, attrs, metaRaw: j };
       META.set(id,out); return out;
     }catch{
-      const out={ id, attrs:[] }; META.set(id,out); return out;
+      const out={ id, attrs:[], metaRaw:null }; META.set(id,out); return out;
     }
   }
   async function loadMetaBatch(ids){
@@ -604,53 +604,68 @@
   }
 
   // --- Cards ---
-  function attrsHTML(attrs, max=4){
-    if (!Array.isArray(attrs)||!attrs.length) return '';
-    const rows=[]; for (const a of attrs){ if(!a.key||a.value==null) continue; rows.push('<li><b>'+a.key+':</b> '+String(a.value)+'</li>'); if(rows.length>=max) break; }
-    return rows.length? '<ul class="attr-bullets">'+rows.join('')+'</ul>' : '';
+  function shortAddrLocal(a){
+    try{
+      if (window.FF && typeof window.FF.shortAddress === 'function'){
+        return window.FF.shortAddress(a);
+      }
+    }catch(_){ }
+    if (!a || typeof a !== 'string') return '—';
+    const t = a.trim();
+    if (!t) return '—';
+    if (t.length <= 10) return t;
+    return t.slice(0,6)+'…'+t.slice(-4);
   }
-  function fmtMeta(it){
+  function formatMetaLineForOwned(it){
+    try{
+      if (window.FF && typeof window.FF.formatOwnerLine === 'function'){
+        return window.FF.formatOwnerLine(it);
+      }
+    }catch(_){ }
+    const ownerLabelRaw = it.ownerYou ? 'You' : shortAddrLocal(it.owner);
+    const ownerLabel = ownerLabelRaw && ownerLabelRaw !== '—' ? ownerLabelRaw : 'Unknown';
     if (it.staked){
       const ago = it.sinceMs ? fmtAgo(it.sinceMs) : null;
-      return ago
-        ? ('<span class="staked-flag">Staked '+ago+'</span> • Owned by You')
-        : '<span class="staked-flag">Staked</span> • Owned by You';
+      const agoHtml = ago ? (' ' + ago) : '';
+      return '<span class="staked-flag">Staked' + agoHtml + ' by ' + ownerLabel + '</span>';
     }
-    return 'Not staked • Owned by You';
+    return 'Owned by ' + ownerLabel;
   }
-  function wireCardActions(scope,it){
-    scope.querySelectorAll('button[data-act]').forEach(btn=>{
-      btn.addEventListener('click', async ()=>{
-        const act = btn.getAttribute('data-act');
-        try{
-          const a = addr || await getConnectedAddress();
-          if (!a) { toast('Connect wallet first'); return; }
-
-          if (act==='stake'){
-            const approved = await checkApproved(a);
-            if (!approved){
-              const stakedIds = await getStakedIds(a).catch(()=>[]);
-              const rewardsRaw = await getRewards(a).catch(()=>null);
-              openApprovePanel(a, { approved:false, staked: stakedIds.length, rewards: rewardsRaw });
-            }else{
-              openStakePanel(a, it.id);
-            }
-          }else if (act==='unstake'){
-            openUnstakePanel(a, it.id);
-          }else if (act==='transfer'){
-            if (it.staked){ toast('This frog is staked. Unstake before transferring.'); return; }
-            openTransferPanel(a, it.id);
-          }
-        }catch{ toast('Action failed'); }
-      });
-    });
+  async function handleStake(id){
+    try{
+      const a = addr || await getConnectedAddress();
+      if (!a){ toast('Connect wallet first'); return; }
+      const approved = await checkApproved(a);
+      if (!approved){
+        const stakedIds = await getStakedIds(a).catch(()=>[]);
+        const rewardsRaw = await getRewards(a).catch(()=>null);
+        openApprovePanel(a, { approved:false, staked: stakedIds.length, rewards: rewardsRaw });
+      }else{
+        openStakePanel(a, id);
+      }
+    }catch{ toast('Action failed'); }
+  }
+  async function handleUnstake(id){
+    try{
+      const a = addr || await getConnectedAddress();
+      if (!a){ toast('Connect wallet first'); return; }
+      openUnstakePanel(a, id);
+    }catch{ toast('Action failed'); }
+  }
+  async function handleTransfer(id){
+    try{
+      const a = addr || await getConnectedAddress();
+      if (!a){ toast('Connect wallet first'); return; }
+      const target = items.find(x=>x.id===id);
+      if (target && target.staked){ toast('This frog is staked. Unstake before transferring.'); return; }
+      openTransferPanel(a, id);
+    }catch{ toast('Action failed'); }
   }
 
   function renderCards(){
     const root = document.querySelector('#ownedGrid');
     if (!root) return;
 
-    // keep list sorted even after optimistic updates
     items.sort(compareByRarity);
 
     root.innerHTML = '';
@@ -664,38 +679,34 @@
 
     updateHeaderOwned();
 
-    items.forEach(it => {
-      const card = document.createElement('article');
-      card.className = 'frog-card';
-      card.setAttribute('data-token-id', String(it.id));
-      if (it.staked) card.setAttribute('data-staked','1');
+    const ownerAddr = addr || null;
+    const ownerShort = ownerAddr ? shortAddrLocal(ownerAddr) : null;
+    const frogs = items.map(it => ({
+      id: it.id,
+      rank: it.rank,
+      attrs: it.attrs,
+      staked: it.staked,
+      sinceMs: it.sinceMs,
+      metaRaw: it.metaRaw,
+      owner: ownerAddr,
+      ownerShort: ownerShort,
+      ownerYou: !!ownerAddr,
+      holder: ownerAddr
+    }));
 
-      const r = Number(it.rank);
-      const hasRank = Number.isFinite(r);
-      const tier = hasRank ? rankTier(r) : 'common';
-      const rankPill = hasRank
-        ? ` <span class="rank-pill rank-${tier}">#${r}</span>`
-        : '';
-
-      const attrs = attrsHTML(it.attrs, 4);
-      const disabledAttrs = it.staked ? ' disabled aria-disabled="true" title="Unstake before transferring"' : '';
-
-      card.innerHTML = [
-        `<img class="thumb" src="${imgFor(it.id)}" alt="${it.id}">`,
-        `<h4 class="title">Frog #${it.id}${rankPill}</h4>`,
-        `<div class="meta">${fmtMeta(it)}</div>`,
-        attrs,
-        `<div class="actions">
-           <button class="btn btn-outline-gray" data-act="${it.staked ? 'unstake' : 'stake'}">${it.staked ? 'Unstake' : 'Stake'}</button>
-           <button class="btn btn-outline-gray ${it.staked ? 'btn-disabled' : ''}" data-act="transfer"${disabledAttrs}>Transfer</button>
-           <a class="btn btn-outline-gray" href="${etherscanToken(it.id)}" target="_blank" rel="noopener">Etherscan</a>
-           <a class="btn btn-outline-gray" href="${imgFor(it.id)}" target="_blank" rel="noopener">Original</a>
-         </div>`
-      ].join('');
-
-      root.appendChild(card);
-      wireCardActions(card, it);
-    });
+    if (window.FF && typeof window.FF.renderFrogCards === 'function'){
+      window.FF.renderFrogCards(root, frogs, {
+        showActions: true,
+        rarityTiers: CFG.RARITY_TIERS,
+        metaLine: formatMetaLineForOwned,
+        onStake: handleStake,
+        onUnstake: handleUnstake,
+        onTransfer: handleTransfer,
+        levelSeconds: Number(CFG.STAKE_LEVEL_SECONDS || (30 * 86400))
+      });
+    }else{
+      root.innerHTML = '<div class="pg-muted">Frog cards unavailable.</div>';
+    }
 
     syncHeights();
   }
@@ -750,7 +761,8 @@
           attrs: m.attrs,
           staked: stakedIds.includes(m.id),
           sinceMs: null,
-          rank: Number.isFinite(rkNum) ? rkNum : undefined
+          rank: Number.isFinite(rkNum) ? rkNum : undefined,
+          metaRaw: m.metaRaw || null
         };
       });
 
@@ -791,7 +803,8 @@
                 id:m.id, attrs:m.attrs,
                 staked: stakedIds.includes(m.id),
                 sinceMs:null,
-                rank: Number.isFinite(rkNum) ? rkNum : undefined
+                rank: Number.isFinite(rkNum) ? rkNum : undefined,
+                metaRaw: m.metaRaw || null
               };
             });
           items = items.concat(more);

--- a/assets/js/owned.js
+++ b/assets/js/owned.js
@@ -265,7 +265,7 @@
     clearList();
     const ids = ST.cache.ownedIds || [];
     if (!ids.length){ setStatus('No owned frogs in this wallet for this collection.'); return; }
-    ids.forEach(id=> ul.appendChild(liCard(id, 'Not staked • Owned by You', ST.addr, false)));
+    ids.forEach(id=> ul.appendChild(liCard(id, 'Owned by You', ST.addr, false)));
     setStatus(`Showing ${ids.length.toLocaleString()} owned frog(s). Scroll for more.`);
   }
 
@@ -275,7 +275,8 @@
     if (!rows.length){ setStatus('No frogs from this wallet are currently staked.'); return; }
     rows.forEach(r=>{
       const sinceMs = r.since ? r.since.getTime() : null;
-      const info = r.since ? `Staked ${fmtAgoMs(Date.now()-sinceMs)} • Owned by You` : 'Staked • Owned by You';
+      const agoLabel = sinceMs ? fmtAgoMs(Date.now()-sinceMs) : null;
+      const info = agoLabel ? `Staked ${agoLabel} by You` : 'Staked by You';
       ul.appendChild(liCard(r.id, info, ST.addr, true, sinceMs));
     });
     setStatus(`Showing ${rows.length} staked frog(s). Scroll for more.`);

--- a/assets/js/pond.js
+++ b/assets/js/pond.js
@@ -265,11 +265,13 @@
 
         // Middle: text block
         const mid = mk('div');
+        const sinceLabel = fmtAgo(r.since);
+        const sinceText = sinceLabel ? ' ' + sinceLabel : '';
         mid.innerHTML =
           `<div style="display:flex;align-items:center;gap:8px;">
              <b>Frog #${r.id}</b> ${pillRank(rank)}
            </div>
-           <div class="muted">Staked ${fmtAgo(r.since)} • Owned by ${r.staker ? shorten(r.staker) : '—'}</div>`;
+           <div class="muted">Staked${sinceText} by ${r.staker ? shorten(r.staker) : '—'}</div>`;
         li.appendChild(mid);
 
         ul.appendChild(li);

--- a/assets/js/rarity-page.js
+++ b/assets/js/rarity-page.js
@@ -1,355 +1,1007 @@
-// assets/js/rarity-page.js
-// Rarity list that matches dashboard card visuals (rank pill tiers, staked line),
-// and uses the same 128×128 DOM layering from frog-renderer.js
+// assets/js/rarity-page.js — vanilla ES5-compatible rarity loader used by
+// rarity.html. This version intentionally avoids optional chaining, default
+// parameters, and other newer syntax so that the cards render in older
+// browsers.
 
-(function(FF = window.FF || {}, CFG = window.FF_CFG || {}) {
+(function(global){
   'use strict';
 
-  // ---------- DOM ----------
-  const GRID       = document.getElementById('rarityGrid');
-  const BTN_MORE   = document.getElementById('btnMore');
-  const BTN_RANK   = document.getElementById('btnSortRank');
-  const BTN_SCORE  = document.getElementById('btnSortScore');
-  const FIND_INPUT = document.getElementById('raritySearchId');
-  const BTN_GO     = document.getElementById('btnGo');
+  var FF  = global.FF     || {};
+  var CFG = global.FF_CFG || {};
+
+  var PAGE_CFG = global.FF_RARITY_PAGE_CONFIG || {};
+  try { delete global.FF_RARITY_PAGE_CONFIG; } catch (errCfg) {}
+
+  var GRID       = document.getElementById('rarityGrid');
+  var BTN_MORE   = document.getElementById('btnMore');
+  var BTN_RANK   = document.getElementById('btnSortRank');
+  var BTN_SCORE  = document.getElementById('btnSortScore');
+  var FIND_INPUT = document.getElementById('raritySearchId');
+  var BTN_GO     = document.getElementById('btnGo');
+  var BTN_LAYOUT = document.getElementById('btnLayoutCycle');
   if (!GRID) return;
 
-  // ---------- Config ----------
-  const JSON_RANKS  = CFG.JSON_PATH || 'assets/freshfrogs_rarity_rankings.json'; // [{id, ranking, score}]
-  const LOOKUP_FILE = 'assets/freshfrogs_rank_lookup.json';                      // optional
-  const PAGE_SIZE   = 60;
-  const SIZE        = 128;
+  var PRIMARY_RANK_FILE = CFG.JSON_PATH || 'assets/freshfrogs_rarity_rankings.json';
+  var LOOKUP_FILE       = 'assets/freshfrogs_rank_lookup.json';
+  var STAKED_ONLY       = !!PAGE_CFG.stakedOnly;
+  var DEFAULT_SORT_MODE = (PAGE_CFG.defaultSortMode || 'rank');
+  var SECOND_SORT_MODE  = PAGE_CFG.secondSortMode === false ? null : (PAGE_CFG.secondSortMode || (STAKED_ONLY ? 'time' : 'score'));
+  var SECOND_SORT_LABEL = PAGE_CFG.secondSortLabel || null;
+  var AUTO_MIN_RENDER   = Number(PAGE_CFG.autoLoadMin) || 0;
+  DEFAULT_SORT_MODE = String(DEFAULT_SORT_MODE || 'rank').toLowerCase();
+  if (SECOND_SORT_MODE) SECOND_SORT_MODE = String(SECOND_SORT_MODE).toLowerCase();
+  var PAGE_SIZE         = Number(PAGE_CFG.pageSize || 60);
+  var SOURCE_PATH       = (CFG.SOURCE_PATH || '').replace(/\/+$/, '');
 
-  const RESERVOIR = {
-    HOST: (CFG.RESERVOIR_HOST || 'https://api.reservoir.tools').replace(/\/+$/,''),
-    KEY:  (CFG.FROG_API_KEY || CFG.RESERVOIR_API_KEY || '')
-  };
+  var RESERVOIR_HOST = (CFG.RESERVOIR_HOST || 'https://api.reservoir.tools').replace(/\/+$/, '');
+  var RESERVOIR_KEY  = CFG.FROG_API_KEY || CFG.RESERVOIR_API_KEY || '';
+  var CTRL_ADDR      = (CFG.CONTROLLER_ADDRESS || '').toLowerCase();
+  var CTRL_DEPLOY    = Number(CFG.CONTROLLER_DEPLOY_BLOCK);
 
-  // ---------- CSS (rank pill + green staked like dashboard) ----------
-  (function injectCSS(){
-    if (document.getElementById('rarity-cards-css')) return;
-    const css = `
-.frog-cards{ display:grid; gap:10px; }
-.frog-card{
-  border:1px solid var(--border);
-  background:var(--panel);
-  border-radius:14px;
-  padding:12px;
-  display:grid; grid-template-columns:auto 1fr; column-gap:12px; row-gap:6px; align-items:start;
-  color:inherit;
-}
-.frog-card .thumb-wrap{ width:${SIZE}px; min-width:${SIZE}px; position:relative; }
-.frog-card canvas.frog-canvas{ width:${SIZE}px; height:${SIZE}px; border-radius:12px; background:var(--panel-2); display:block; }
-.frog-card .title{ margin:0; font-weight:900; font-size:18px; letter-spacing:-.01em; display:flex; align-items:center; gap:8px; }
-.frog-card .meta{ color:var(--muted); font-size:12px; }
-.frog-card .attr-bullets{ list-style:disc; margin:6px 0 0 18px; padding:0; color:var(--muted); }
-.frog-card .attr-bullets li{ display:list-item; font-size:12px; margin:2px 0; }
-
-.rank-pill{
-  display:inline-flex; align-items:center; gap:6px;
-  border:1px solid var(--border); border-radius:999px; padding:3px 8px;
-  font-size:11px; font-weight:700; letter-spacing:.01em;
-  background:color-mix(in srgb, var(--panel) 35%, transparent);
-}
-.rank-pill::before{ content:'◆'; font-size:12px; line-height:1; }
-.rank-legendary{ color:#f59e0b; border-color: color-mix(in srgb, #f59e0b 70%, var(--border)); }
-.rank-legendary::before{ color:#f59e0b; }
-.rank-epic{ color:#a855f7; border-color: color-mix(in srgb, #a855f7 70%, var(--border)); }
-.rank-epic::before{ color:#a855f7; }
-.rank-rare{ color:#38bdf8; border-color: color-mix(in srgb, #38bdf8 70%, var(--border)); }
-.rank-rare::before{ color:#38bdf8; }
-.rank-common{ color:inherit; border-color:var(--border); }
-.rank-common::before{ color:var(--muted); }
-
-.meta .staked-flag{ color:#22c55e; font-weight:700; }
-.actions{ grid-column:1 / -1; display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
-.btn{ font-family:var(--font-ui); border:1px solid var(--border); background:transparent; color:inherit; border-radius:8px; padding:6px 10px; font-weight:700; font-size:12px; line-height:1; }
-.btn-outline-gray{ border-color: color-mix(in srgb, #9ca3af 70%, var(--border)); color: color-mix(in srgb, #ffffff 65%, #9ca3af); }
-    `;
-    const s=document.createElement('style'); s.id='rarity-cards-css'; s.textContent=css; document.head.appendChild(s);
-  })();
-
-  // ---------- Utils ----------
-  const asNum = (x)=> { const n = Number(x); return Number.isFinite(n)?n:NaN; };
-  const getRankLike = (o)=> asNum(o.rank ?? o.ranking ?? o.position ?? o.place);
-  const shortAddr = (a)=> a && typeof a==='string' ? (a.length>10 ? (a.slice(0,6)+'…'+a.slice(-4)) : a) : '—';
-  const traitKey  = (t)=> (t?.key ?? t?.trait_type ?? t?.traitType ?? t?.trait ?? '').toString().trim();
-  const traitVal  = (t)=> (t?.value ?? t?.trait_value ?? '').toString().trim();
-
-  // Same thresholds as dashboard (owned-panel.js)
-  function rankTier(rank){
-    const r = Number(rank);
-    if (!Number.isFinite(r)) return 'common';
-    const T = (CFG.RARITY_TIERS) || { legendary: 50, epic: 250, rare: 800 };
-    if (r <= T.legendary) return 'legendary';
-    if (r <= T.epic)      return 'epic';
-    if (r <= T.rare)      return 'rare';
-    return 'common';
+  var allItems   = [];
+  var viewItems  = [];
+  var offset     = 0;
+  var sortMode   = DEFAULT_SORT_MODE;
+  if (sortMode !== 'rank' && sortMode !== 'score' && sortMode !== 'time') {
+    sortMode = 'rank';
   }
-  function rankPill(rank){
-    const tier = rankTier(rank);
-    const span = document.createElement('span');
-    span.className = `rank-pill rank-${tier}`;
-    span.textContent = `#${rank}`;
-    return span;
-  }
-  function fmtAgo(ms){
-    if(!ms||!isFinite(ms))return null;
-    const s=Math.max(0,Math.floor((Date.now()-ms)/1000));
-    const d=Math.floor(s/86400); if(d>=1) return d+'d ago';
-    const h=Math.floor((s%86400)/3600);  if(h>=1) return h+'h ago';
-    const m=Math.floor((s%3600)/60);     if(m>=1) return m+'m ago';
-    return s+'s ago';
+  var renderCount = 0;
+  var lookupMap  = null; // Map<id, {rank, score}>
+  var currentUser = null;
+  var STORAGE_KEY_LAYOUT = 'ff_card_layout';
+  var DEFAULT_CARD_LAYOUTS = [
+    { id: 'classic',   label: 'Classic' },
+    { id: 'aurora',    label: 'Aurora Glow' },
+    { id: 'ember',     label: 'Ember Forge' },
+    { id: 'midnight',  label: 'Midnight Noir' },
+    { id: 'glass',     label: 'Glass Vault' },
+    { id: 'grove',     label: 'Canopy Grove' },
+    { id: 'retro',     label: 'Retro Pop' },
+    { id: 'oasis',     label: 'Desert Oasis' },
+    { id: 'parchment', label: 'Archivist' },
+    { id: 'circuit',   label: 'Circuit Breaker' },
+    { id: 'sunset',    label: 'Sunset Mirage' }
+  ];
+  var CARD_LAYOUTS = DEFAULT_CARD_LAYOUTS.slice();
+  var layoutIndex = 0;
+
+  function uiError(msg) {
+    GRID.innerHTML = '<div class="pg-muted" style="padding:10px">' + msg + '</div>';
+    renderCount = 0;
   }
 
-  // owner logic
-  async function getUserAddress(){
-    try{ if (window.FF_WALLET?.address) return window.FF_WALLET.address; }catch{}
-    try{ if (window.ethereum?.request){ const a=await window.ethereum.request({method:'eth_accounts'}); return a?.[0]||null; } }catch{}
+  function clearGrid() {
+    GRID.innerHTML = '';
+    renderCount = 0;
+    if (GRID.classList && GRID.classList.add) {
+      GRID.classList.add('frog-cards');
+    }
+  }
+
+  function ensureMoreBtn() {
+    if (!BTN_MORE) return;
+    BTN_MORE.style.display = offset < viewItems.length ? 'inline-flex' : 'none';
+  }
+
+  function asNum(x) {
+    var n = Number(x);
+    return isFinite(n) ? n : NaN;
+  }
+
+  function labelForSort(mode) {
+    if (mode === 'rank') return 'Sort: Rank ↑';
+    if (mode === 'score') return 'Sort: Score ↓';
+    if (mode === 'time' || mode === 'stakedTime') return 'Sort: Time ↑';
+    return 'Sort';
+  }
+
+  function getRankLike(obj) {
+    if (!obj) return NaN;
+    if (obj.rank != null) return asNum(obj.rank);
+    if (obj.ranking != null) return asNum(obj.ranking);
+    if (obj.position != null) return asNum(obj.position);
+    if (obj.place != null) return asNum(obj.place);
+    return NaN;
+  }
+
+  function shortAddr(addr) {
+    if (!addr || typeof addr !== 'string') return '\u2014';
+    if (addr.length <= 10) return addr;
+    return addr.slice(0, 6) + '\u2026' + addr.slice(-4);
+  }
+
+  function traitKey(t) {
+    if (!t) return '';
+    var keys = ['key', 'trait_type', 'traitType', 'trait'];
+    for (var i = 0; i < keys.length; i++) {
+      if (t[keys[i]] != null) {
+        return String(t[keys[i]]).trim();
+      }
+    }
+    return '';
+  }
+
+  function traitVal(t) {
+    if (!t) return '';
+    var keys = ['value', 'trait_value'];
+    for (var i = 0; i < keys.length; i++) {
+      if (t[keys[i]] != null) {
+        return String(t[keys[i]]).trim();
+      }
+    }
+    return '';
+  }
+
+  function fmtAgo(ms) {
+    if (!ms || !isFinite(ms)) return null;
+    var s = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+    var d = Math.floor(s / 86400);
+    if (d >= 1) return d + 'd ago';
+    var h = Math.floor((s % 86400) / 3600);
+    if (h >= 1) return h + 'h ago';
+    var m = Math.floor((s % 3600) / 60);
+    if (m >= 1) return m + 'm ago';
+    return s + 's ago';
+  }
+
+  function sinceMs(sec) {
+    if (sec == null) return null;
+    var n = Number(sec);
+    if (!isFinite(n)) return null;
+    return n > 1e12 ? n : n * 1000;
+  }
+
+  function readStoredLayout() {
+    try {
+      if (global.localStorage) {
+        return global.localStorage.getItem(STORAGE_KEY_LAYOUT);
+      }
+    } catch (err) {}
     return null;
   }
 
-  // On-chain owner (fallback to Reservoir)
-  let _web3,_col;
-  function getWeb3(){ if (_web3) return _web3; _web3 = new Web3(window.ethereum || Web3.givenProvider || ""); return _web3; }
-  function getCollectionContract(){
-    if (_col) return _col;
-    if (!CFG.COLLECTION_ADDRESS || !window.COLLECTION_ABI) return null;
-    _col = new (getWeb3()).eth.Contract(window.COLLECTION_ABI, CFG.COLLECTION_ADDRESS);
-    return _col;
-  }
-  async function ownerFromContract(id){
-    try{ const c=getCollectionContract(); if (!c) return null; return await c.methods.ownerOf(String(id)).call(); }
-    catch{ return null; }
-  }
-  async function ownerFromReservoir(id){
-    if (!RESERVOIR.KEY || !CFG.COLLECTION_ADDRESS) return null;
-    const url = `${RESERVOIR.HOST}/owners/v2?tokens=${encodeURIComponent(`${CFG.COLLECTION_ADDRESS}:${id}`)}&limit=1`;
-    try{
-      const r = await fetch(url, { headers: { accept:'application/json', 'x-api-key': RESERVOIR.KEY } });
-      if (!r.ok) return null;
-      const j = await r.json();
-      const own = j?.owners?.[0]?.owner;
-      return (typeof own==='string' && own.startsWith('0x')) ? own : null;
-    }catch{ return null; }
-  }
-  async function fetchOwnerOf(id){
-    const onchain = await ownerFromContract(id);
-    if (onchain) return onchain;
-    const api = await ownerFromReservoir(id);
-    return api || null;
-  }
-
-  // staking info (reuses any adapter if present)
-  async function fetchStakeInfo(id){
+  function storeLayout(id) {
     try {
-      if (FF.staking?.getStakeInfo) return await FF.staking.getStakeInfo(id);
-      if (window.STAKING_ADAPTER?.getStakeInfo) return await window.STAKING_ADAPTER.getStakeInfo(id);
-    } catch {}
-    return { staked:false, since:null };
+      if (global.localStorage) {
+        global.localStorage.setItem(STORAGE_KEY_LAYOUT, id);
+      }
+    } catch (err) {}
   }
-  const sinceMs = (sec)=> {
-    if (sec==null) return null;
-    const n = Number(sec); if (!Number.isFinite(n)) return null;
-    return n > 1e12 ? n : n*1000;
-  };
 
-  // metadata
-  async function fetchMeta(id){
-    const tries = [
-      `frog/json/${id}.json`,
-      `frog/${id}.json`,
-      `assets/frogs/${id}.json`
-    ];
-    for (const u of tries){
-      try{ const r=await fetch(u,{cache:'no-store'}); if (r.ok) return await r.json(); }catch{}
+  function applyLayout(idx) {
+    if (!CARD_LAYOUTS.length) return;
+    if (idx < 0) idx = 0;
+    if (idx >= CARD_LAYOUTS.length) idx = 0;
+    layoutIndex = idx;
+    var layout = CARD_LAYOUTS[idx];
+    try {
+      if (document && document.documentElement) {
+        document.documentElement.setAttribute('data-card-layout', layout.id);
+      }
+    } catch (err1) {}
+    if (BTN_LAYOUT) {
+      BTN_LAYOUT.textContent = 'Layout: ' + layout.label + ' (' + (idx + 1) + '/' + CARD_LAYOUTS.length + ')';
     }
-    return { name:`Frog #${id}`, attributes:[] };
+    storeLayout(layout.id);
+    try {
+      if (global.FF && typeof global.FF.setCardLayout === 'function') {
+        global.FF.setCardLayout(layout.id);
+      }
+    } catch (err2) {}
   }
 
-  // ---------- Rankings ----------
-  async function fetchJSON(url){ const r=await fetch(url,{cache:'no-store'}); if(!r.ok) throw new Error(r.status); return r.json(); }
-  function normalizeRankingsArray(arr){
-    return arr.map(x => ({
-      id:   asNum(x.id ?? x.tokenId ?? x.token_id ?? x.frogId ?? x.frog_id),
-      rank: getRankLike(x),
-      score: asNum(x.score ?? x.rarityScore ?? x.points ?? 0)
-    }))
-    .filter(r => Number.isFinite(r.id) && Number.isFinite(r.rank) && r.rank>0)
-    .sort((a,b)=>a.rank-b.rank);
+  function applyLayoutById(id) {
+    if (!id) {
+      applyLayout(0);
+      return;
+    }
+    for (var i = 0; i < CARD_LAYOUTS.length; i++) {
+      if (CARD_LAYOUTS[i].id === id) {
+        applyLayout(i);
+        return;
+      }
+    }
+    applyLayout(0);
   }
-  async function loadRankings(){
-    const primary = await fetchJSON(JSON_RANKS).catch(()=>[]);
-    let rows = Array.isArray(primary) ? normalizeRankingsArray(primary) : [];
-    if (!rows.length){
-      // optional lookup fallback
-      try{
-        const j = await fetchJSON(LOOKUP_FILE);
-        if (j && typeof j === 'object'){
-          rows = Object.entries(j).map(([rk,id])=>({ id: asNum(id), rank: asNum(rk), score: 0 }))
-                  .filter(r=>Number.isFinite(r.id)&&Number.isFinite(r.rank))
-                  .sort((a,b)=>a.rank-b.rank);
+
+  function initLayoutCycle() {
+    try {
+      if (global.FF && typeof global.FF.availableCardLayouts === 'function') {
+        var avail = global.FF.availableCardLayouts();
+        if (Array.isArray(avail) && avail.length) {
+          var next = [];
+          for (var i = 0; i < avail.length; i++) {
+            var row = avail[i];
+            if (!row) continue;
+            var id = null;
+            var label = null;
+            if (typeof row === 'string') {
+              id = row;
+            } else if (typeof row === 'object') {
+              if (row.id != null) id = row.id;
+              else if (row.layout != null) id = row.layout;
+              else if (row[0] != null) id = row[0];
+              label = row.label || row.name || null;
+            }
+            if (!id) continue;
+            id = String(id);
+            if (!label) {
+              try {
+                if (global.FF && typeof global.FF.cardLayoutLabel === 'function') {
+                  label = global.FF.cardLayoutLabel(id);
+                }
+              } catch (errLabel) {}
+            }
+            if (!label) {
+              label = id.charAt(0).toUpperCase() + id.slice(1);
+            }
+            next.push({ id: id, label: label });
+          }
+          if (next.length) {
+            CARD_LAYOUTS = next;
+          }
         }
-      }catch{}
+      }
+    } catch (errFetch) {}
+    if (!CARD_LAYOUTS.length) {
+      CARD_LAYOUTS = DEFAULT_CARD_LAYOUTS.slice();
     }
-    return rows;
+    var startId = null;
+    try {
+      if (document && document.documentElement) {
+        startId = document.documentElement.getAttribute('data-card-layout');
+      }
+    } catch (err) {}
+    if (!startId) {
+      startId = readStoredLayout();
+    }
+    if (!startId) {
+      startId = CARD_LAYOUTS.length ? CARD_LAYOUTS[0].id : 'classic';
+    }
+    applyLayoutById(startId);
+    if (BTN_LAYOUT) {
+      BTN_LAYOUT.addEventListener('click', function(){
+        applyLayout((layoutIndex + 1) % CARD_LAYOUTS.length);
+      });
+    }
   }
 
-  // ---------- Card ----------
-  function buildCard(rec, userAddr){
-    const { id, rank, meta, owner, stake } = rec;
+  function getUserAddress() {
+    return new Promise(function(resolve){
+      try {
+        if (global.FF_WALLET && global.FF_WALLET.address) {
+          resolve(global.FF_WALLET.address);
+          return;
+        }
+      } catch (err) {}
 
-    const card = document.createElement('article');
-    card.className = 'frog-card';
-    card.setAttribute('data-token-id', String(id));
+      try {
+        if (global.ethereum && typeof global.ethereum.request === 'function') {
+          global.ethereum.request({ method: 'eth_accounts' }).then(function(arr){
+            resolve(arr && arr.length ? arr[0] : null);
+          }).catch(function(){ resolve(null); });
+          return;
+        }
+      } catch (err2) {}
 
-    // media: host a hidden canvas; FF.renderFrog will stack DOM layers in the same order as metadata
-    const media = document.createElement('div');
-    media.className = 'thumb-wrap';
-    const cv = document.createElement('canvas');
-    cv.className = 'frog-canvas'; cv.width = SIZE; cv.height = SIZE;
-    media.appendChild(cv);
-
-    // title: Frog #id + rank pill (dashboard style)
-    const title = document.createElement('h4');
-    title.className = 'title';
-    title.textContent = meta?.name || `Frog #${id}`;
-    const pill = rankPill(rank);
-    title.appendChild(pill);
-
-    // subtitle: staked line + owner
-    const metaLine = document.createElement('div');
-    metaLine.className = 'meta';
-    const me = userAddr && owner && userAddr.toLowerCase() === owner.toLowerCase();
-
-    const stakeSpan = document.createElement('span');
-    if (stake?.staked) {
-      const ago = sinceMs(stake?.since) ? fmtAgo(sinceMs(stake?.since)) : null;
-      stakeSpan.className = 'staked-flag';
-      stakeSpan.textContent = ago ? `Staked ${ago}` : 'Staked';
-    } else {
-      stakeSpan.textContent = 'Not staked';
-    }
-    const sep = document.createElement('span'); sep.textContent = ' • ';
-    const ownerSpan = document.createElement('span');
-    ownerSpan.textContent = `Owned by ${me ? 'You' : shortAddr(owner)}`;
-
-    metaLine.appendChild(stakeSpan);
-    metaLine.appendChild(sep);
-    metaLine.appendChild(ownerSpan);
-
-    // attributes (vertical)
-    const list = document.createElement('ul');
-    list.className = 'attr-bullets';
-    (Array.isArray(meta?.attributes)? meta.attributes: []).forEach(a=>{
-      const k=traitKey(a), v=traitVal(a); if(!k||!v) return;
-      const li=document.createElement('li'); li.innerHTML = `<b>${k}:</b> ${v}`; list.appendChild(li);
+      resolve(null);
     });
+  }
 
-    // actions (view-only)
-    const actions = document.createElement('div'); actions.className='actions';
-    const aOS  = document.createElement('a'); aOS.className='btn btn-outline-gray'; aOS.textContent='OpenSea';
-    aOS.href = `https://opensea.io/assets/ethereum/${CFG.COLLECTION_ADDRESS}/${id}`; aOS.target='_blank'; aOS.rel='noopener';
-    const aScan= document.createElement('a'); aScan.className='btn btn-outline-gray'; aScan.textContent='Etherscan';
-    aScan.href = `https://etherscan.io/token/${CFG.COLLECTION_ADDRESS}?a=${id}`; aScan.target='_blank'; aScan.rel='noopener';
-    const aOrig= document.createElement('a'); aOrig.className='btn btn-outline-gray'; aOrig.textContent='Original';
-    aOrig.href = `frog/${id}.png`; aOrig.target='_blank'; aOrig.rel='noopener';
-    actions.appendChild(aOS); actions.appendChild(aScan); actions.appendChild(aOrig);
+  function fetchJson(url) {
+    return fetch(url, { cache: 'no-store' }).then(function(res){
+      if (!res.ok) throw new Error('HTTP ' + res.status + ' fetching ' + url);
+      return res.json();
+    });
+  }
 
-    // compose
-    card.appendChild(media);
-    const right = document.createElement('div');
+  function parseRankToIdMap(obj) {
+    var map = new Map();
+    for (var key in obj) {
+      if (!obj.hasOwnProperty(key)) continue;
+      var rank = asNum(key);
+      var id = asNum(obj[key]);
+      if (isFinite(rank) && isFinite(id)) {
+        map.set(id, { rank: rank, score: 0 });
+      }
+    }
+    return map.size ? map : null;
+  }
+
+  function normalizeRankingsArray(arr) {
+    return arr
+      .map(function(x){
+        var id = asNum(x && (x.id != null ? x.id : (x.tokenId != null ? x.tokenId : (x.token_id != null ? x.token_id : (x.frogId != null ? x.frogId : x.frog_id)))));
+        var rank = getRankLike(x);
+        var score = asNum(x && (x.score != null ? x.score : (x.rarityScore != null ? x.rarityScore : x.points)));
+        if (!isFinite(score)) score = 0;
+        return { id: id, rank: rank, score: score };
+      })
+      .filter(function(r){ return isFinite(r.id) && isFinite(r.rank) && r.rank > 0; })
+      .sort(function(a, b){ return a.rank - b.rank; });
+  }
+
+  function loadLookup() {
+    return fetchJson(LOOKUP_FILE).then(function(json){
+      if (Array.isArray(json)) {
+        var map = new Map();
+        for (var i = 0; i < json.length; i++) {
+          var id = asNum(json[i]);
+          if (isFinite(id)) map.set(id, { rank: i + 1, score: 0 });
+        }
+        lookupMap = map.size ? map : null;
+      } else if (json && typeof json === 'object') {
+        lookupMap = parseRankToIdMap(json);
+      } else {
+        lookupMap = null;
+      }
+    }).catch(function(err){
+      console.warn('[rarity] lookup load failed', err);
+      lookupMap = null;
+    });
+  }
+
+  function loadPrimaryRanks() {
+    return fetchJson(PRIMARY_RANK_FILE).then(function(json){
+      if (!Array.isArray(json)) return [];
+      var arr = normalizeRankingsArray(json);
+      if (lookupMap) {
+        arr.forEach(function(r){
+          var lk = lookupMap.get(r.id);
+          if (!lk) return;
+          if (!isFinite(r.rank) && isFinite(lk.rank)) r.rank = lk.rank;
+          if (!isFinite(r.score) && isFinite(lk.score)) r.score = lk.score;
+        });
+        arr.sort(function(a, b){ return a.rank - b.rank; });
+      }
+      return arr;
+    }).catch(function(err){
+      console.warn('[rarity] primary rankings load failed', err);
+      return [];
+    });
+  }
+
+  function fetchMeta(id) {
+    var tries = [
+      'frog/json/' + id + '.json',
+      'frog/' + id + '.json',
+      'assets/frogs/' + id + '.json'
+    ];
+
+    var next = function(ix){
+      if (ix >= tries.length) {
+        return Promise.resolve({ name: 'Frog #' + id, image: 'frog/' + id + '.png', attributes: [] });
+      }
+      var url = tries[ix];
+      return fetch(url, { cache: 'no-store' }).then(function(res){
+        if (!res.ok) return next(ix + 1);
+        return res.json();
+      }).catch(function(){
+        return next(ix + 1);
+      });
+    };
+
+    return next(0);
+  }
+
+  function normalizeAttrs(meta) {
+    var out = [];
+    var arr = meta && Array.isArray(meta.attributes) ? meta.attributes : [];
+    for (var i = 0; i < arr.length; i++) {
+      var key = traitKey(arr[i]);
+      var val = traitVal(arr[i]);
+      if (!key || !val) continue;
+      out.push({ key: key, value: val });
+    }
+    return out;
+  }
+
+  var _web3 = null;
+  var _collection = null;
+  var _controller = null;
+  var _stakeSinceCache = new Map();
+  var _stakerCache = new Map();
+
+  function getWeb3(){
+    if (_web3) return _web3;
+    if (!global.Web3) return null;
+
+    var provider = null;
+    if (global.ethereum) {
+      provider = global.ethereum;
+    } else if (global.Web3.givenProvider) {
+      provider = global.Web3.givenProvider;
+    } else if (CFG.RPC_URL && global.Web3 && global.Web3.providers && global.Web3.providers.HttpProvider) {
+      try {
+        provider = new global.Web3.providers.HttpProvider(CFG.RPC_URL);
+      } catch (err) {
+        console.warn('[rarity] failed to build HttpProvider', err);
+      }
+    }
+
+    if (!provider) return null;
+
+    _web3 = new global.Web3(provider);
+    return _web3;
+  }
+
+  function resolveCollectionAbi(){
+    if (typeof global.COLLECTION_ABI !== 'undefined') return global.COLLECTION_ABI;
+    if (typeof global.collection_abi !== 'undefined') return global.collection_abi;
+    if (typeof COLLECTION_ABI !== 'undefined') return COLLECTION_ABI;
+    if (typeof collection_abi !== 'undefined') return collection_abi;
+    return null;
+  }
+
+  function resolveControllerAbi(){
+    if (typeof global.CONTROLLER_ABI !== 'undefined') return global.CONTROLLER_ABI;
+    if (typeof global.controller_abi !== 'undefined') return global.controller_abi;
+    if (typeof CONTROLLER_ABI !== 'undefined') return CONTROLLER_ABI;
+    if (typeof controller_abi !== 'undefined') return controller_abi;
+    return null;
+  }
+
+  function getCollectionContract(){
+    if (_collection) return _collection;
+    if (!CFG.COLLECTION_ADDRESS) return null;
+    var abi = resolveCollectionAbi();
+    if (!abi || !abi.length) return null;
+    var web3 = getWeb3();
+    if (!web3 || !web3.eth || !web3.eth.Contract) return null;
+    _collection = new web3.eth.Contract(abi, CFG.COLLECTION_ADDRESS);
+    return _collection;
+  }
+
+  function getControllerContract(){
+    if (_controller) return _controller;
+    if (!CFG.CONTROLLER_ADDRESS) return null;
+    var abi = resolveControllerAbi();
+    if (!abi || !abi.length) return null;
+    var web3 = getWeb3();
+    if (!web3 || !web3.eth || !web3.eth.Contract) return null;
+    _controller = new web3.eth.Contract(abi, CFG.CONTROLLER_ADDRESS);
+    return _controller;
+  }
+
+  function isHexAddress(addr){
+    return typeof addr === 'string' && addr.indexOf('0x') === 0 && addr.length === 42;
+  }
+
+  function padTokenHex(id){
+    var n = Number(id);
+    if (!isFinite(n) || n < 0) n = 0;
+    var hex = n.toString(16);
+    while (hex.length < 64) hex = '0' + hex;
+    return '0x' + hex;
+  }
+
+  function fetchStakeTimestamp(id){
+    if (_stakeSinceCache.has(id)) return Promise.resolve(_stakeSinceCache.get(id));
+
+    return new Promise(function(resolve){
+      try {
+        var web3 = getWeb3();
+        if (!web3 || !web3.eth || !web3.eth.getPastLogs || !CFG.COLLECTION_ADDRESS || !CTRL_ADDR) {
+          _stakeSinceCache.set(id, null);
+          resolve(null);
+          return;
+        }
+
+        var topics = [
+          '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+          null,
+          '0x000000000000000000000000' + CTRL_ADDR.slice(2),
+          padTokenHex(id)
+        ];
+
+        var fromBlock = isFinite(CTRL_DEPLOY) && CTRL_DEPLOY > 0 ? '0x' + CTRL_DEPLOY.toString(16) : '0x0';
+
+        web3.eth.getPastLogs({
+          fromBlock: fromBlock,
+          toBlock: 'latest',
+          address: CFG.COLLECTION_ADDRESS,
+          topics: topics
+        }).then(function(logs){
+          if (!logs || !logs.length) {
+            _stakeSinceCache.set(id, null);
+            resolve(null);
+            return;
+          }
+          var last = logs[logs.length - 1];
+          web3.eth.getBlock(last.blockNumber).then(function(block){
+            var ts = block && block.timestamp != null ? Number(block.timestamp) : null;
+            var ms = ts ? (ts > 1e12 ? ts : ts * 1000) : null;
+            _stakeSinceCache.set(id, ms);
+            resolve(ms);
+          }).catch(function(err){
+            console.warn('[rarity] stake block lookup failed', err);
+            _stakeSinceCache.set(id, null);
+            resolve(null);
+          });
+        }).catch(function(err2){
+          console.warn('[rarity] stake log lookup failed', err2);
+          _stakeSinceCache.set(id, null);
+          resolve(null);
+        });
+      } catch (err3) {
+        console.warn('[rarity] stake timestamp error', err3);
+        _stakeSinceCache.set(id, null);
+        resolve(null);
+      }
+    });
+  }
+
+  function fetchStakerAddress(id){
+    if (_stakerCache.has(id)) return Promise.resolve(_stakerCache.get(id));
+
+    return new Promise(function(resolve){
+      try {
+        var ctrl = getControllerContract();
+        if (!ctrl || !ctrl.methods || !ctrl.methods.stakerAddress) {
+          _stakerCache.set(id, null);
+          resolve(null);
+          return;
+        }
+        ctrl.methods.stakerAddress(String(id)).call().then(function(addr){
+          if (!addr || !isHexAddress(addr) || addr === '0x0000000000000000000000000000000000000000') {
+            _stakerCache.set(id, null);
+            resolve(null);
+            return;
+          }
+          _stakerCache.set(id, addr);
+          resolve(addr);
+        }).catch(function(err){
+          console.warn('[rarity] staker lookup failed', err);
+          _stakerCache.set(id, null);
+          resolve(null);
+        });
+      } catch (err2) {
+        console.warn('[rarity] staker error', err2);
+        _stakerCache.set(id, null);
+        resolve(null);
+      }
+    });
+  }
+
+  function ownerFromContract(id){
+    return new Promise(function(resolve){
+      try {
+        var contract = getCollectionContract();
+        if (!contract) { resolve(null); return; }
+        contract.methods.ownerOf(String(id)).call().then(function(addr){
+          resolve(addr || null);
+        }).catch(function(){ resolve(null); });
+      } catch (err) {
+        resolve(null);
+      }
+    });
+  }
+
+  function ownerFromReservoir(id){
+    if (!RESERVOIR_KEY || !CFG.COLLECTION_ADDRESS) return Promise.resolve(null);
+    var token = CFG.COLLECTION_ADDRESS + ':' + id;
+    var url = RESERVOIR_HOST + '/owners/v2?tokens=' + encodeURIComponent(token) + '&limit=1';
+    return fetch(url, {
+      headers: {
+        accept: 'application/json',
+        'x-api-key': RESERVOIR_KEY
+      }
+    }).then(function(res){
+      if (!res.ok) return null;
+      return res.json();
+    }).then(function(json){
+      if (!json || !json.owners || !json.owners.length) return null;
+      var owner = json.owners[0] && json.owners[0].owner;
+      return (typeof owner === 'string' && owner.indexOf('0x') === 0) ? owner : null;
+    }).catch(function(err){
+      console.warn('[rarity] reservoir owner lookup failed', err);
+      return null;
+    });
+  }
+
+  function fetchOwnerOf(id){
+    return ownerFromContract(id).then(function(onchain){
+      var holder = isHexAddress(onchain) ? onchain : null;
+      var controllerOwned = !!(holder && CTRL_ADDR && holder.toLowerCase() === CTRL_ADDR);
+
+      if (controllerOwned) {
+        return fetchStakerAddress(id).then(function(staker){
+          return (staker ? Promise.resolve(staker) : ownerFromReservoir(id)).then(function(ownerGuess){
+            return fetchStakeTimestamp(id).then(function(since){
+              return {
+                owner: staker || ownerGuess || null,
+                holder: holder,
+                controllerOwned: true,
+                stakeSinceMs: since,
+                staker: staker || null
+              };
+            });
+          });
+        });
+      }
+
+      if (holder) {
+        return {
+          owner: holder,
+          holder: holder,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      }
+
+      return ownerFromReservoir(id).then(function(resOwner){
+        return {
+          owner: resOwner || null,
+          holder: holder,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      });
+    }).catch(function(err){
+      console.warn('[rarity] owner lookup fallback', err);
+      return ownerFromReservoir(id).then(function(resOwner){
+        return {
+          owner: resOwner || null,
+          holder: null,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      }).catch(function(){
+        return {
+          owner: null,
+          holder: null,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      });
+    });
+  }
+
+  function fetchStakeInfo(id){
+    return new Promise(function(resolve){
+      var done = false;
+      function finish(info){
+        if (done) return;
+        done = true;
+        resolve(info || { staked: false, since: null });
+      }
+
+      try {
+        if (FF.staking && typeof FF.staking.getStakeInfo === 'function') {
+          FF.staking.getStakeInfo(id).then(function(info){ finish(info); }).catch(function(){ finish(null); });
+          return;
+        }
+      } catch (err) {
+        console.warn('[rarity] staking info via FF.staking failed', err);
+      }
+
+      try {
+        if (global.STAKING_ADAPTER && typeof global.STAKING_ADAPTER.getStakeInfo === 'function') {
+          global.STAKING_ADAPTER.getStakeInfo(id).then(function(info){ finish(info); }).catch(function(){ finish(null); });
+          return;
+        }
+      } catch (err2) {
+        console.warn('[rarity] staking adapter lookup failed', err2);
+      }
+
+      finish(null);
+    });
+  }
+
+  function normalizeStake(info){
+    var staked = info && !!info.staked;
+    var since = null;
+    if (info) {
+      if (info.since != null) since = info.since;
+      else if (info.sinceMs != null) since = info.sinceMs;
+      else if (info.since_ms != null) since = info.since_ms;
+      else if (info.stakedSince != null) since = info.stakedSince;
+    }
+    return { staked: staked, sinceMs: sinceMs(since) };
+  }
+
+  function fallbackMetaLine(item){
+    var ownerLabel = null;
+    if (item.ownerYou) ownerLabel = 'You';
+    else if (item.ownerShort && item.ownerShort !== '\u2014') ownerLabel = item.ownerShort;
+    else if (item.owner) ownerLabel = shortAddr(item.owner);
+    else if (item.holder) ownerLabel = shortAddr(item.holder);
+    if (!ownerLabel) ownerLabel = 'Unknown';
+    if (item.staked) {
+      var ago = item.sinceMs ? fmtAgo(item.sinceMs) : null;
+      var agoHtml = ago ? ('<span class="ago-line">' + ago + '</span>') : '';
+      return '<span class="staked-flag">Staked</span> by ' + ownerLabel + agoHtml;
+    }
+    return 'Owned by ' + ownerLabel;
+  }
+
+  function metaLineForCard(item){
+    try {
+      if (global.FF && typeof global.FF.formatOwnerLine === 'function') {
+        return global.FF.formatOwnerLine(item);
+      }
+    } catch (err) {
+      console.warn('[rarity] meta line formatter failed', err);
+    }
+    return fallbackMetaLine(item);
+  }
+
+  function buildFallbackCard(rec) {
+    var card = document.createElement('article');
+    card.className = 'frog-card';
+    card.setAttribute('data-token-id', String(rec.id));
+
+    var row = document.createElement('div');
+    row.className = 'row';
+
+    var thumbWrap = document.createElement('div');
+    thumbWrap.className = 'thumb-wrap';
+
+    var img = document.createElement('img');
+    img.className = 'thumb';
+    img.alt = (rec.metaRaw && rec.metaRaw.name) ? rec.metaRaw.name : ('Frog #' + rec.id);
+    img.loading = 'lazy';
+    img.src = (rec.metaRaw && rec.metaRaw.image) ? rec.metaRaw.image : (SOURCE_PATH + '/frog/' + rec.id + '.png');
+    thumbWrap.appendChild(img);
+
+    var right = document.createElement('div');
+    var title = document.createElement('h4');
+    title.className = 'title';
+    title.textContent = (rec.metaRaw && rec.metaRaw.name) ? rec.metaRaw.name : ('Frog #' + rec.id);
+    if (rec.rank != null) {
+      var pill = document.createElement('span');
+      pill.className = 'pill';
+      pill.textContent = '♦ #' + rec.rank;
+      title.appendChild(pill);
+    }
+    var metaLine = document.createElement('div');
+    metaLine.className = 'meta';
+    metaLine.innerHTML = metaLineForCard(rec);
+
     right.appendChild(title);
     right.appendChild(metaLine);
-    if (list.childNodes.length) right.appendChild(list);
-    right.appendChild(actions);
-    card.appendChild(right);
 
-    // render layered frog (metadata order) at 128×128
-    (async ()=>{
-      try{
-        await (FF.renderFrog ? FF.renderFrog(cv, rec.metaRaw || meta, { size: SIZE, tokenId: id }) : Promise.reject());
-      }catch{
-        // fallback to still image if renderer not available
-        const img = document.createElement('img'); img.src = `frog/${id}.png`; img.alt = String(id); img.className = 'frog-canvas';
-        media.innerHTML=''; media.appendChild(img);
-      }
-    })();
+    if (rec.attrs && rec.attrs.length) {
+      var list = document.createElement('ul');
+      list.className = 'attr-bullets';
+      rec.attrs.forEach(function(attr){
+        var li = document.createElement('li');
+        li.innerHTML = '<b>' + attr.key + ':</b> ' + attr.value;
+        list.appendChild(li);
+      });
+      right.appendChild(list);
+    }
 
+    row.appendChild(thumbWrap);
+    row.appendChild(right);
+    card.appendChild(row);
     return card;
   }
 
-  // ---------- Paging / render ----------
-  let rows=[], view=[], offset=0, sortMode='rank';
-  function ensureMoreBtn(){ if (BTN_MORE) BTN_MORE.style.display = offset < view.length ? 'inline-flex' : 'none'; }
-  function clearGrid(){ GRID.innerHTML=''; GRID.classList.add('frog-cards'); }
+  function buildCard(rec) {
+    if (global.FF && typeof global.FF.buildFrogCard === 'function') {
+      return global.FF.buildFrogCard({
+        id: rec.id,
+        rank: rec.rank,
+        attrs: rec.attrs,
+        staked: rec.staked,
+        sinceMs: rec.sinceMs,
+        metaRaw: rec.metaRaw,
+        owner: rec.owner,
+        ownerShort: rec.ownerShort,
+        ownerYou: rec.ownerYou,
+        holder: rec.holder
+      }, {
+        showActions: false,
+        rarityTiers: CFG.RARITY_TIERS,
+        metaLine: metaLineForCard
+      });
+    }
+    return buildFallbackCard(rec);
+  }
 
-  async function loadMore(userAddr){
-    const slice = view.slice(offset, offset + PAGE_SIZE);
-    if (!slice.length) { ensureMoreBtn(); return; }
-
-    const metas  = await Promise.all(slice.map(x => fetchMeta(x.id)));
-    const owners = await Promise.all(slice.map(x => fetchOwnerOf(x.id)));
-    const stakes = await Promise.all(slice.map(x => fetchStakeInfo(x.id)));
-
-    for (let i=0;i<slice.length;i++){
-      slice[i].meta = metas[i];
-      slice[i].metaRaw = metas[i]; // pass through for renderer
-      slice[i].owner = owners[i] || null;
-      slice[i].stake = stakes[i] || {staked:false, since:null};
+  function loadMore() {
+    var slice = viewItems.slice(offset, offset + PAGE_SIZE);
+    if (!slice.length) {
+      ensureMoreBtn();
+      return Promise.resolve();
     }
 
-    const frag=document.createDocumentFragment();
-    slice.forEach(rec => frag.appendChild(buildCard(rec, userAddr)));
-    GRID.appendChild(frag);
+    return Promise.all(slice.map(function(x){ return fetchMeta(x.id); }))
+      .then(function(metas){
+        return Promise.all(slice.map(function(x){ return fetchOwnerOf(x.id); })).then(function(owners){
+          return Promise.all(slice.map(function(x){ return fetchStakeInfo(x.id); })).then(function(stakes){
+            var frag = document.createDocumentFragment();
+            var appended = 0;
+            for (var i = 0; i < slice.length; i++) {
+              var meta = metas[i] || { attributes: [] };
+              var ownerInfo = owners[i] || {};
+              if (ownerInfo && typeof ownerInfo === 'string') {
+                ownerInfo = { owner: ownerInfo, holder: ownerInfo, controllerOwned: false, stakeSinceMs: null, staker: null };
+              }
+              var stake = normalizeStake(stakes[i] || null);
+              var attrs = normalizeAttrs(meta);
 
-    offset += slice.length;
-    ensureMoreBtn();
+              var isStaked = stake.staked || !!ownerInfo.controllerOwned;
+              var since = stake.sinceMs || ownerInfo.stakeSinceMs || null;
+              var actualOwner = ownerInfo.owner || null;
+              if (!actualOwner && !isStaked && ownerInfo.holder) {
+                actualOwner = ownerInfo.holder;
+              }
+              if (!actualOwner && ownerInfo.staker) {
+                actualOwner = ownerInfo.staker;
+              }
+
+              var ownerShort = actualOwner ? shortAddr(actualOwner) : null;
+              var ownerYou = false;
+              if (currentUser && actualOwner && typeof currentUser === 'string' && typeof actualOwner === 'string') {
+                ownerYou = currentUser.toLowerCase() === actualOwner.toLowerCase();
+              } else if (currentUser && !actualOwner && ownerInfo.holder && typeof ownerInfo.holder === 'string') {
+                ownerYou = currentUser.toLowerCase() === ownerInfo.holder.toLowerCase();
+              }
+
+              slice[i].staked = isStaked;
+              slice[i].sinceMs = since;
+              slice[i].owner = actualOwner;
+              slice[i].ownerShort = ownerShort;
+              slice[i].ownerYou = ownerYou;
+              slice[i].holder = ownerInfo && ownerInfo.holder ? ownerInfo.holder : null;
+              slice[i].metaRaw = meta;
+              slice[i].attrs = attrs;
+
+              if (STAKED_ONLY && !isStaked) {
+                continue;
+              }
+
+              var rec = {
+                id: slice[i].id,
+                rank: slice[i].rank,
+                score: slice[i].score,
+                metaRaw: meta,
+                attrs: attrs,
+                staked: isStaked,
+                sinceMs: since,
+                owner: actualOwner,
+                ownerShort: ownerShort,
+                ownerYou: ownerYou,
+                holder: ownerInfo && ownerInfo.holder ? ownerInfo.holder : null
+              };
+              frag.appendChild(buildCard(rec));
+              appended += 1;
+            }
+
+            if (appended) {
+              GRID.appendChild(frag);
+              renderCount += appended;
+            }
+            offset += slice.length;
+            ensureMoreBtn();
+            if (STAKED_ONLY) {
+              if (!appended && offset < viewItems.length) {
+                return loadMore();
+              }
+              if (!appended && offset >= viewItems.length && renderCount === 0) {
+                uiError('No staked frogs found.');
+                if (BTN_MORE) BTN_MORE.style.display = 'none';
+                return;
+              }
+              if (AUTO_MIN_RENDER > 0 && renderCount < AUTO_MIN_RENDER && offset < viewItems.length) {
+                return loadMore();
+              }
+            }
+          });
+        });
+      }).catch(function(err){
+        console.error('[rarity] loadMore failed', err);
+        uiError('Failed to load frogs.');
+      });
   }
 
-  function resort(userAddr){
-    view.sort((a,b)=> sortMode==='rank'
-      ? (a.rank - b.rank)
-      : ((b.score - a.score) || (a.rank - b.rank))
-    );
-    offset = 0; clearGrid(); loadMore(userAddr);
+  function resort() {
+    viewItems.sort(function(a, b){
+      var aRank = (a && a.rank != null) ? a.rank : Number.POSITIVE_INFINITY;
+      var bRank = (b && b.rank != null) ? b.rank : Number.POSITIVE_INFINITY;
+      if (sortMode === 'time') {
+        var aStaked = !!(a && a.staked);
+        var bStaked = !!(b && b.staked);
+        if (aStaked !== bStaked) {
+          return bStaked - aStaked;
+        }
+        var ta = (a && a.sinceMs != null) ? a.sinceMs : null;
+        var tb = (b && b.sinceMs != null) ? b.sinceMs : null;
+        if (ta == null && tb != null) return 1;
+        if (tb == null && ta != null) return -1;
+        if (ta != null && tb != null && ta !== tb) return ta - tb;
+        return aRank - bRank;
+      }
+      if (sortMode === 'score') {
+        var sa = (a && a.score != null) ? a.score : -Infinity;
+        var sb = (b && b.score != null) ? b.score : -Infinity;
+        var diff = (sb - sa);
+        if (diff) return diff;
+        return aRank - bRank;
+      }
+      return aRank - bRank;
+    });
+    offset = 0;
+    clearGrid();
+    loadMore();
   }
 
-  function jumpToId(id, userAddr){
-    const ix = view.findIndex(x => x.id === id);
+  function jumpToId(id) {
+    var ix = -1;
+    for (var i = 0; i < viewItems.length; i++) {
+      if (viewItems[i].id === id) { ix = i; break; }
+    }
     if (ix < 0) return;
     offset = Math.floor(ix / PAGE_SIZE) * PAGE_SIZE;
-    clearGrid(); loadMore(userAddr);
+    clearGrid();
+    loadMore();
   }
 
-  // ---------- Init ----------
-  (async function init(){
-    try{
-      rows = await loadRankings();
-      if (!rows.length){
-        GRID.innerHTML = `<div class="pg-muted" style="padding:10px">Could not load rarity data. Check JSON files and try a hard refresh.</div>`;
-        return;
+  function init() {
+    loadLookup().then(function(){
+      return loadPrimaryRanks();
+    }).then(function(primary){
+      if (primary && primary.length) {
+        allItems = primary;
+      } else if (lookupMap && lookupMap.size) {
+        allItems = Array.from(lookupMap).map(function(entry){
+          return { id: entry[0], rank: entry[1].rank, score: entry[1].score || 0 };
+        }).sort(function(a, b){ return a.rank - b.rank; });
+      } else {
+        uiError('Could not load rarity data. Check both JSON files\' shapes.');
+        return null;
       }
-      view = rows.slice();
-      offset = 0; clearGrid();
 
-      const userAddr = await getUserAddress();
-      await loadMore(userAddr);
-      BTN_MORE && (BTN_MORE.style.display = 'inline-flex');
+      viewItems = allItems.slice(0);
+      offset = 0;
+      clearGrid();
 
-      BTN_MORE?.addEventListener('click', () => loadMore(userAddr));
-      BTN_RANK?.addEventListener('click', ()=>{ sortMode='rank'; resort(userAddr); });
-      BTN_SCORE?.addEventListener('click', ()=>{ sortMode='score'; resort(userAddr); });
-      BTN_GO?.addEventListener('click', ()=>{
-        const id = Number(FIND_INPUT.value);
-        if (Number.isFinite(id)) jumpToId(id, userAddr);
+      return getUserAddress().then(function(addr){
+        currentUser = addr;
+        return loadMore();
+      });
+    }).then(function(){
+      if (BTN_MORE) BTN_MORE.style.display = 'inline-flex';
+
+      if (BTN_MORE) BTN_MORE.addEventListener('click', function(){ loadMore(); });
+      if (BTN_RANK) {
+        BTN_RANK.textContent = labelForSort('rank');
+        BTN_RANK.addEventListener('click', function(){ sortMode = 'rank'; resort(); });
+      }
+      if (BTN_SCORE) {
+        if (!SECOND_SORT_MODE) {
+          BTN_SCORE.style.display = 'none';
+        } else {
+          BTN_SCORE.textContent = SECOND_SORT_LABEL || labelForSort(SECOND_SORT_MODE);
+          BTN_SCORE.addEventListener('click', function(){ sortMode = SECOND_SORT_MODE; resort(); });
+        }
+      }
+      if (BTN_GO) BTN_GO.addEventListener('click', function(){
+        var id = Number(FIND_INPUT && FIND_INPUT.value);
+        if (isFinite(id)) jumpToId(id);
       });
 
-      if (window.ethereum?.on) window.ethereum.on('accountsChanged', ()=> location.reload());
-    }catch(e){
-      console.error('[rarity] init failed', e);
-      GRID.innerHTML = `<div class="pg-muted" style="padding:10px">Failed to initialize rarity view.</div>`;
-    }
-  })();
+      if (global.ethereum && typeof global.ethereum.on === 'function') {
+        global.ethereum.on('accountsChanged', function(){ global.location.reload(); });
+      }
+    }).catch(function(err){
+      console.error('[rarity] init error', err);
+      uiError('Failed to initialize rarity view. See console for details.');
+    });
+  }
 
-})(window.FF, window.FF_CFG);
+  initLayoutCycle();
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})(window);

--- a/owned.html
+++ b/owned.html
@@ -125,7 +125,7 @@
         <article class="frog-card" data-token-id="12">
           <img class="thumb" src="frog/12.png" alt="12">
           <h4 class="title">Frog #12 <span class="pill" data-rank>Rank —</span></h4>
-          <div class="meta">Not staked • Owned by You</div>
+          <div class="meta">Owned by You</div>
           <ul class="attr-list" aria-label="Attributes">
             <li class="attr">Background: <b>Blue</b></li>
             <li class="attr">Eyes: <b>Laser</b></li>
@@ -144,7 +144,7 @@
         <article class="frog-card" data-token-id="77">
           <img class="thumb" src="frog/77.png" alt="77">
           <h4 class="title">Frog #77 <span class="pill" data-rank>Rank —</span></h4>
-          <div class="meta">Staked 1123d ago • Owned by You</div>
+          <div class="meta"><span class="staked-flag">Staked 1123d ago by You</span></div>
           <ul class="attr-list" aria-label="Attributes">
             <li class="attr">Background: <b>Green</b></li>
             <li class="attr">Eyes: <b>Wide</b></li>
@@ -163,7 +163,7 @@
         <article class="frog-card" data-token-id="404">
           <img class="thumb" src="frog/404.png" alt="404">
           <h4 class="title">Frog #404 <span class="pill" data-rank>Rank —</span></h4>
-          <div class="meta">Not staked • Owned by You</div>
+          <div class="meta">Owned by You</div>
           <ul class="attr-list" aria-label="Attributes">
             <li class="attr">Background: <b>Charcoal</b></li>
             <li class="attr">Eyes: <b>Sleepy</b></li>

--- a/pond.html
+++ b/pond.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>freshfrogs — Rarity</title>
+  <title>freshfrogs — Pond</title>
 
   <link rel="stylesheet" href="assets/css/styles.css" />
 
   <style>
-    /* mirror collection.html base feel */
     .pg-wrap{ padding:20px; }
     img{ image-rendering: pixelated; image-rendering: crisp-edges; }
 
@@ -17,7 +16,6 @@
     .pg-card-head h3{ margin:0; font-weight:800; font-size:16px; }
     .pg-muted{ color:var(--muted); font-size:13px; }
 
-    /* Hero (identical structure so topbar.js pills work) */
     .frog-hero{ margin:28px auto 38px; max-width:1100px; }
     .frog-title{ margin:0 0 6px 0; font:900 28px/1.15 'Space Grotesk', var(--font-ui); letter-spacing:-.01em; text-align:center; }
     .frog-strip{ display:flex; gap:12px; align-items:center; justify-content:center; overflow:hidden; padding:0; }
@@ -26,10 +24,8 @@
     .frog-strip img{ width:64px; height:64px; object-fit:contain; }
     @media (max-width:520px){ .frog-hero{ margin:22px auto 30px; } .frog-strip{ gap:10px; } }
 
-    /* Single main panel with the grid */
     .page-grid{ max-width:1100px; margin:0 auto; display:grid; gap:16px; grid-template-columns: 1fr; }
 
-    /* Use the same card styles defined in collection.html */
     .frog-card{ border:1px solid var(--border); background:var(--panel); border-radius:14px; padding:12px;
       display:grid; grid-template-columns:auto 1fr; column-gap:12px; row-gap:6px; align-items:start; color:inherit; }
     .frog-card .thumb{
@@ -62,12 +58,10 @@
       color: color-mix(in srgb, #ffffff 85%, #22c55e);
     }
 
-    /* Grid */
     #rarityGrid{ display:grid; gap:10px; grid-template-columns: 1fr; }
     @media (min-width:720px){ #rarityGrid{ grid-template-columns: 1fr 1fr; } }
     @media (min-width:1024px){ #rarityGrid{ grid-template-columns: 1fr 1fr 1fr; } }
 
-    /* Rank badge for image (optional; your card renderer can also inject this) */
     .rank-badge{
       position:absolute; top:8px; left:8px;
       background:var(--ink,#0c0c0f); color:var(--fg,#eaeaea);
@@ -79,9 +73,8 @@
 </head>
 <body>
   <div class="pg-wrap container">
-    <!-- HERO (keep identical so topbar pills render) -->
     <section class="frog-hero">
-      <h1 class="frog-title">freshfrogs.github.io</h1>
+      <h1 class="frog-title">Staked Frogs</h1>
       <div class="frog-strip">
         <div class="tile"><img src="frog/12.png"  alt="12"></div>
         <div class="tile"><img src="frog/77.png"  alt="77"></div>
@@ -96,17 +89,17 @@
     <div class="page-grid">
       <section class="pg-card">
         <div class="pg-card-head">
-          <h3>Rarity Rankings</h3>
+          <h3>Currently Staked</h3>
           <div style="display:flex;gap:8px;flex-wrap:wrap;">
             <button id="btnSortRank"  class="btn btn-outline-gray">Sort: Rank ↑</button>
-            <button id="btnSortScore" class="btn btn-outline-gray">Sort: Score ↓</button>
+            <button id="btnSortScore" class="btn btn-outline-gray">Sort: Time ↑</button>
             <input id="raritySearchId" type="number" min="1" placeholder="Find Frog ID…" style="width:140px; padding:6px 10px; border:1px solid var(--border); border-radius:8px; background:var(--panel-2); color:inherit;">
             <button id="btnGo" class="btn btn-outline-gray">Go</button>
           </div>
         </div>
 
         <div id="rarityGrid">
-          <div class="pg-muted">Loading rarity…</div>
+          <div class="pg-muted">Loading staked frogs…</div>
         </div>
 
         <div style="display:grid; place-items:center; margin-top:10px;">
@@ -117,7 +110,6 @@
   </div>
 
   <script>
-    /* keep hero strip behavior the same */
     function layoutFrogStrip(){
       var strip = document.querySelector('.frog-strip'); if(!strip) return;
       var tiles = Array.prototype.slice.call(strip.querySelectorAll('.tile'));
@@ -131,28 +123,30 @@
     document.addEventListener('DOMContentLoaded', layoutFrogStrip);
   </script>
 
-  <!-- match your collection.html script stack/order (only what we need here) -->
   <script src="https://cdn.jsdelivr.net/npm/web3@1.10.4/dist/web3.min.js"></script>
   <script src="assets/js/config.js"></script>
   <script src="assets/js/utils.js"></script>
   <script src="assets/js/rarity.js"></script>
   <script src="assets/js/modal.js"></script>
 
-  <!-- ABIs (some renderers or links reference addresses) -->
   <script src="assets/abi/collection_abi.js"></script>
   <script src="assets/abi/controller_abi.js"></script>
 
-  <!-- Shared staking adapter so we can resolve stake owners/age like collection.html -->
   <script src="assets/js/staking-adapter.js"></script>
 
-  <!-- Card + renderer (same as dashboard) -->
   <script src="assets/js/frog-renderer.js"></script>
   <script src="assets/js/frog-cards.js" defer></script>
 
-  <!-- Top bar pills -->
   <script src="assets/js/topbar.js"></script>
 
-  <!-- Rarity page glue -->
+  <script>
+    window.FF_RARITY_PAGE_CONFIG = {
+      stakedOnly: true,
+      defaultSortMode: 'rank',
+      secondSortMode: 'time',
+      autoLoadMin: 9
+    };
+  </script>
   <script src="assets/js/rarity-page.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- limit the shared frog card component to the classic styling and show staked durations on their own line for clarity
- extend the rarity loader with configuration for staked-only filtering, time-based sorting, and auto-loading so the UI can reuse it for different views
- add pond.html as a staked-frog roster wired into the shared rarity scripts while keeping rarity.html on the classic layout

## Testing
- ✅ browser_container.run_playwright_script (manual pond.html verification)


------
https://chatgpt.com/codex/tasks/task_e_68db79b842988331a0be89ddd6adef49