### PR TITLE
Redesign site layout with cohesive navigation

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -4,38 +4,200 @@
 
 /* ---------- Theme tokens ---------- */
 :root{
-  --font-ui: Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;
+  --font-ui: "Inter",system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
   --font-display: 'Space Grotesk',var(--font-ui);
 
-  --bg:#0b0f13;
-  --ink:#e9f2ff;
-  --muted:#90a3b3;
+  --bg:#05060f;
+  --bg-soft:#0b1322;
+  --ink:#f6f8ff;
+  --muted:#9cb1d6;
 
-  --panel:#0f141a;
-  --panel-2:#121821;
-  --panelSoft: var(--panel-2);
+  --panel:#0d1624;
+  --panel-2:#152135;
+  --panelSoft:#101c2c;
 
-  --ring: rgba(255,255,255,.08);
-  --border: var(--ring);
-  --card: var(--panel);
-  --card-2: var(--panel-2);
-  --shadow: 0 8px 24px rgba(0,0,0,.35);
+  --ring:rgba(124,195,255,.3);
+  --border:rgba(86,140,214,.35);
+  --card:#0c1728;
+  --card-2:#19283d;
+  --shadow:0 32px 70px rgba(3,12,28,.6);
 
-  --accent:#35d49a;
-  --accent-ink:#051311;
+  --accent:#7df0b2;
+  --accent-ink:#042116;
 
-  --radius:10px;
+  --card-frame:rgba(125,240,178,.45);
+  --card-foil:linear-gradient(150deg,rgba(125,240,178,.22),transparent 68%);
+  --card-inner:rgba(8,18,31,.72);
+  --card-shadow:0 36px 72px rgba(4,12,26,.55);
+  --hero-gradient:radial-gradient(circle at 18% 24%,rgba(125,240,178,.28),transparent 64%);
+  --hero-ring:rgba(125,240,178,.26);
+  --thumb-border:rgba(125,240,178,.42);
+
+  --radius:12px;
   --radius-pill:999px;
 
-  --focus: 0 0 0 3px color-mix(in srgb, var(--accent) 26%, transparent);
-  --list-max: 420px;
+  --focus:0 0 0 3px color-mix(in srgb,var(--accent) 28%,transparent);
+  --list-max:460px;
 }
-html[data-theme="pastel"]{
-  --bg:#f6fbff; --ink:#11202b; --muted:#5d7a8a;
-  --panel:#ffffff; --panel-2:#eaf5ff; --panelSoft:#eaf5ff;
-  --ring:rgba(0,0,0,.10); --border:rgba(0,0,0,.10);
-  --card: var(--panel); --card-2: var(--panel-2);
-  --accent:#8ad1ff; --accent-ink:#08121a;
+
+html[data-theme="atlas"]{
+  --bg:#08121e; --ink:#f2f6ff; --muted:#8ba0c3;
+  --panel:#101c2c; --panel-2:#142234; --panelSoft:#132030;
+  --ring:rgba(112,168,255,.26); --border:rgba(76,119,197,.35);
+  --card:#101d31; --card-2:#172941;
+  --accent:#66d5ff; --accent-ink:#05121b;
+  --card-frame:rgba(102,213,255,.5);
+  --card-foil:linear-gradient(140deg,rgba(118,203,255,.18),transparent 65%);
+  --card-inner:rgba(11,21,37,.65);
+  --card-shadow:0 28px 55px rgba(7,14,30,.55);
+  --shadow:0 28px 55px rgba(7,14,30,.55);
+  --hero-gradient:radial-gradient(circle at 20% 20%,rgba(118,203,255,.35),transparent 60%);
+  --hero-ring:rgba(102,213,255,.25);
+  --thumb-border:rgba(118,203,255,.38);
+}
+
+html[data-theme="moonglow"]{
+  --bg:#0a0718; --ink:#f5edff; --muted:#c1a4ff;
+  --panel:#140f2a; --panel-2:#1c1538; --panelSoft:#191232;
+  --ring:rgba(192,140,255,.26); --border:rgba(192,140,255,.28);
+  --card:#140f2c; --card-2:#1f1740;
+  --accent:#a678ff; --accent-ink:#1b0a2e;
+  --card-frame:rgba(182,130,255,.55);
+  --card-foil:linear-gradient(150deg,rgba(255,180,255,.2),transparent 70%);
+  --card-inner:rgba(20,14,38,.7);
+  --card-shadow:0 32px 62px rgba(16,8,33,.6);
+  --shadow:0 32px 62px rgba(16,8,33,.6);
+  --hero-gradient:radial-gradient(circle at 80% 10%,rgba(166,120,255,.3),transparent 65%);
+  --hero-ring:rgba(166,120,255,.26);
+  --thumb-border:rgba(166,120,255,.38);
+}
+
+html[data-theme="sunset"]{
+  --bg:#1a0c12; --ink:#fff3ed; --muted:#ffb6a4;
+  --panel:#291219; --panel-2:#331820; --panelSoft:#2f151d;
+  --ring:rgba(255,120,90,.26); --border:rgba(255,120,90,.3);
+  --card:#271018; --card-2:#3b1c26;
+  --accent:#ff8b5f; --accent-ink:#240b07;
+  --card-frame:rgba(255,152,104,.45);
+  --card-foil:linear-gradient(150deg,rgba(255,195,120,.22),transparent 70%);
+  --card-inner:rgba(34,12,18,.7);
+  --card-shadow:0 34px 64px rgba(30,8,15,.58);
+  --shadow:0 34px 64px rgba(30,8,15,.58);
+  --hero-gradient:radial-gradient(circle at 15% 15%,rgba(255,166,115,.28),transparent 60%);
+  --hero-ring:rgba(255,140,95,.24);
+  --thumb-border:rgba(255,152,104,.4);
+}
+
+html[data-theme="evergreen"]{
+  --bg:#07150f; --ink:#e9ffef; --muted:#8bd4a6;
+  --panel:#0e2218; --panel-2:#153225; --panelSoft:#122a1f;
+  --ring:rgba(103,210,152,.28); --border:rgba(88,196,140,.32);
+  --card:#0e2118; --card-2:#1a3728;
+  --accent:#6de1a8; --accent-ink:#042015;
+  --card-frame:rgba(109,225,168,.45);
+  --card-foil:linear-gradient(150deg,rgba(150,255,198,.18),transparent 70%);
+  --card-inner:rgba(9,24,17,.72);
+  --card-shadow:0 30px 60px rgba(4,20,12,.58);
+  --shadow:0 30px 60px rgba(4,20,12,.58);
+  --hero-gradient:radial-gradient(circle at 85% 20%,rgba(133,255,190,.28),transparent 65%);
+  --hero-ring:rgba(109,225,168,.26);
+  --thumb-border:rgba(133,255,190,.36);
+}
+
+html[data-theme="lilypad"]{
+  --bg:#f0f8f3; --ink:#173025; --muted:#4b7c63;
+  --panel:#ffffff; --panel-2:#e4f2ea; --panelSoft:#edf7f1;
+  --ring:rgba(76,140,110,.18); --border:rgba(76,140,110,.2);
+  --card:#ffffff; --card-2:#f1fbf6;
+  --accent:#64c89b; --accent-ink:#0a1f15;
+  --card-frame:rgba(100,200,155,.38);
+  --card-foil:linear-gradient(140deg,rgba(155,220,190,.25),transparent 70%);
+  --card-inner:rgba(240,250,244,.9);
+  --card-shadow:0 18px 40px rgba(70,140,100,.22);
+  --shadow:0 18px 40px rgba(70,140,100,.22);
+  --hero-gradient:radial-gradient(circle at 10% 10%,rgba(120,210,165,.3),transparent 60%);
+  --hero-ring:rgba(120,210,165,.24);
+  --thumb-border:rgba(120,210,165,.4);
+}
+
+html[data-theme="abyss"]{
+  --bg:#030d12; --ink:#e3f8ff; --muted:#77b8d4;
+  --panel:#061720; --panel-2:#0a2330; --panelSoft:#071d28;
+  --ring:rgba(70,160,200,.32); --border:rgba(70,160,200,.34);
+  --card:#071924; --card-2:#0d2a38;
+  --accent:#3fd1ff; --accent-ink:#02151f;
+  --card-frame:rgba(63,209,255,.5);
+  --card-foil:linear-gradient(150deg,rgba(120,220,255,.25),transparent 65%);
+  --card-inner:rgba(6,22,32,.75);
+  --card-shadow:0 32px 62px rgba(2,16,24,.6);
+  --shadow:0 32px 62px rgba(2,16,24,.6);
+  --hero-gradient:radial-gradient(circle at 75% 25%,rgba(80,210,255,.32),transparent 70%);
+  --hero-ring:rgba(80,210,255,.26);
+  --thumb-border:rgba(80,210,255,.4);
+}
+
+html[data-theme="horizon"]{
+  --bg:#f3f7ff; --ink:#13203d; --muted:#5d6f8f;
+  --panel:#ffffff; --panel-2:#e8efff; --panelSoft:#eff4ff;
+  --ring:rgba(74,120,220,.16); --border:rgba(74,120,220,.18);
+  --card:#ffffff; --card-2:#f1f6ff;
+  --accent:#5a8cff; --accent-ink:#0a183d;
+  --card-frame:rgba(90,140,255,.35);
+  --card-foil:linear-gradient(140deg,rgba(120,170,255,.25),transparent 70%);
+  --card-inner:rgba(242,247,255,.95);
+  --card-shadow:0 20px 44px rgba(70,110,190,.2);
+  --shadow:0 20px 44px rgba(70,110,190,.2);
+  --hero-gradient:radial-gradient(circle at 80% 10%,rgba(120,170,255,.28),transparent 65%);
+  --hero-ring:rgba(120,170,255,.24);
+  --thumb-border:rgba(120,170,255,.38);
+}
+
+html[data-theme="embercore"]{
+  --bg:#0d0c0b; --ink:#fcefe4; --muted:#d3b49a;
+  --panel:#1b1613; --panel-2:#251e1a; --panelSoft:#201a17;
+  --ring:rgba(255,150,90,.28); --border:rgba(210,120,70,.32);
+  --card:#1a1512; --card-2:#2a211c;
+  --accent:#ff9250; --accent-ink:#2c1407;
+  --card-frame:rgba(255,146,80,.45);
+  --card-foil:linear-gradient(150deg,rgba(255,195,140,.24),transparent 70%);
+  --card-inner:rgba(24,16,12,.75);
+  --card-shadow:0 36px 66px rgba(20,12,8,.6);
+  --shadow:0 36px 66px rgba(20,12,8,.6);
+  --hero-gradient:radial-gradient(circle at 18% 15%,rgba(255,162,100,.3),transparent 60%);
+  --hero-ring:rgba(255,146,80,.26);
+  --thumb-border:rgba(255,146,80,.4);
+}
+
+html[data-theme="frostbite"]{
+  --bg:#edf7ff; --ink:#123049; --muted:#4f7390;
+  --panel:#ffffff; --panel-2:#dfefff; --panelSoft:#e8f4ff;
+  --ring:rgba(68,136,196,.16); --border:rgba(68,136,196,.18);
+  --card:#ffffff; --card-2:#e9f4ff;
+  --accent:#5bb7ff; --accent-ink:#052035;
+  --card-frame:rgba(91,183,255,.35);
+  --card-foil:linear-gradient(150deg,rgba(150,210,255,.25),transparent 70%);
+  --card-inner:rgba(239,249,255,.9);
+  --card-shadow:0 22px 44px rgba(80,140,200,.2);
+  --shadow:0 22px 44px rgba(80,140,200,.2);
+  --hero-gradient:radial-gradient(circle at 20% 20%,rgba(130,200,255,.28),transparent 60%);
+  --hero-ring:rgba(130,200,255,.22);
+  --thumb-border:rgba(130,200,255,.36);
+}
+
+html[data-theme="citrine"]{
+  --bg:#0b0b12; --ink:#f8f5e6; --muted:#d6c99a;
+  --panel:#14131d; --panel-2:#1d1b27; --panelSoft:#191824;
+  --ring:rgba(214,184,82,.26); --border:rgba(214,184,82,.3);
+  --card:#14131e; --card-2:#221f30;
+  --accent:#ffda69; --accent-ink:#241d08;
+  --card-frame:rgba(255,218,105,.45);
+  --card-foil:linear-gradient(150deg,rgba(255,230,150,.26),transparent 70%);
+  --card-inner:rgba(19,18,28,.74);
+  --card-shadow:0 36px 68px rgba(12,12,25,.6);
+  --shadow:0 36px 68px rgba(12,12,25,.6);
+  --hero-gradient:radial-gradient(circle at 75% 15%,rgba(255,218,105,.3),transparent 65%);
+  --hero-ring:rgba(255,218,105,.25);
+  --thumb-border:rgba(255,218,105,.36);
 }
 
 /* ---------- Base ---------- */
@@ -633,4 +795,358 @@ a.btn{ display:inline-flex; align-items:center; justify-content:center; text-dec
 .btn-outline-gray:hover{
   background:color-mix(in srgb, var(--ink) 8%, transparent);
   border-color:color-mix(in srgb, var(--ink) 28%, transparent);
+}
+
+/* ---------- Layout Refresh 2024 ---------- */
+.ff-body{
+  min-height:100vh;
+  margin:0;
+  background:
+    radial-gradient(circle at 12% 18%, rgba(125,240,178,.22), transparent 55%),
+    radial-gradient(circle at 88% 8%, rgba(124,195,255,.18), transparent 58%),
+    linear-gradient(180deg, rgba(6,12,24,.85) 0%, rgba(5,8,18,.92) 100%),
+    var(--bg);
+  color:var(--ink);
+  font:16px/1.6 var(--font-ui);
+}
+.ff-body a{ color:inherit; text-decoration:none; }
+.ff-body a:hover{ color:color-mix(in srgb,var(--accent) 70%, var(--ink) 20%); }
+.sr-only{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0; }
+
+.ff-site{ min-height:100vh; display:flex; flex-direction:column; position:relative; }
+.ff-main{ flex:1; display:flex; flex-direction:column; }
+.ff-container{ width:min(1220px, 100%); margin:0 auto; padding:0 clamp(22px, 6vw, 56px); }
+
+.ff-masthead{
+  position:sticky;
+  top:0;
+  z-index:60;
+  background:color-mix(in srgb,var(--bg-soft, #0b1322) 78%, transparent);
+  border-bottom:1px solid color-mix(in srgb,var(--border) 70%, transparent);
+  backdrop-filter:blur(18px);
+}
+.ff-masthead__inner{
+  height:78px;
+  display:flex;
+  align-items:center;
+  gap:28px;
+}
+.ff-logo{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  font:900 20px/1 var(--font-display);
+  letter-spacing:-.02em;
+}
+.ff-logo span{
+  display:inline-grid;
+  place-items:center;
+  width:34px; height:34px;
+  border-radius:12px;
+  background:linear-gradient(135deg, rgba(125,240,178,.4) 0%, rgba(20,36,50,.9) 100%);
+  border:1px solid color-mix(in srgb,var(--accent) 60%, transparent);
+  box-shadow:0 12px 22px rgba(0,0,0,.35);
+}
+.ff-nav{ margin-left:auto; display:flex; gap:24px; align-items:center; }
+.ff-nav a{
+  font-weight:600;
+  font-size:.95rem;
+  color:color-mix(in srgb,var(--muted) 75%, var(--ink) 15%);
+  position:relative;
+  padding:10px 0;
+}
+.ff-nav a::after{
+  content:"";
+  position:absolute;
+  left:0; right:0; bottom:-6px;
+  height:2px;
+  border-radius:2px;
+  background:color-mix(in srgb,var(--accent) 60%, transparent);
+  transform:scaleX(0);
+  transform-origin:center;
+  transition:transform .18s ease;
+}
+.ff-nav a:hover::after,
+.ff-nav a[aria-current="page"]::after{
+  transform:scaleX(1);
+}
+
+.ff-button{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:10px;
+  padding:.65rem 1.05rem;
+  border-radius:14px;
+  font-weight:700;
+  border:1px solid color-mix(in srgb,var(--accent) 35%, transparent);
+  background:linear-gradient(140deg, color-mix(in srgb,var(--panel-2) 78%, transparent) 0%, color-mix(in srgb,var(--panelSoft) 82%, transparent) 100%);
+  color:var(--ink);
+  transition:transform .12s ease, box-shadow .18s ease, background .18s ease;
+}
+.ff-button:hover{ transform:translateY(-2px); box-shadow:0 16px 28px rgba(4,12,24,.32); }
+.ff-button:active{ transform:translateY(0); }
+.ff-button--solid{
+  background:linear-gradient(135deg, color-mix(in srgb,var(--accent) 86%, transparent) 0%, color-mix(in srgb,var(--accent) 55%, transparent) 100%);
+  color:var(--accent-ink);
+  border-color:color-mix(in srgb,var(--accent) 70%, transparent);
+  box-shadow:0 18px 36px color-mix(in srgb,var(--accent) 30%, transparent);
+}
+.ff-button--ghost{
+  background:transparent;
+  border-color:color-mix(in srgb,var(--ink) 16%, transparent);
+  color:color-mix(in srgb,var(--muted) 80%, var(--ink) 10%);
+}
+.ff-button--ghost:hover{
+  color:var(--ink);
+  background:color-mix(in srgb,var(--panelSoft) 65%, transparent);
+}
+
+.ff-hero{
+  position:relative;
+  padding: clamp(82px, 12vw, 140px) 0 clamp(68px, 10vw, 110px);
+  overflow:hidden;
+}
+.ff-hero::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at 85% 20%, rgba(124,195,255,.16), transparent 60%);
+  pointer-events:none;
+}
+.ff-hero__inner{
+  position:relative;
+  display:grid;
+  gap:clamp(32px, 8vw, 80px);
+  grid-template-columns:minmax(0, 1.05fr) minmax(0, .95fr);
+  align-items:center;
+}
+@media (max-width:960px){
+  .ff-hero__inner{ grid-template-columns:1fr; }
+  .ff-hero__media{ order:-1; justify-self:center; }
+}
+.ff-eyebrow{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  font-weight:700;
+  font-size:.82rem;
+  letter-spacing:.2em;
+  text-transform:uppercase;
+  color:color-mix(in srgb,var(--muted) 80%, var(--ink) 5%);
+}
+.ff-eyebrow::before{
+  content:"";
+  width:34px; height:2px;
+  border-radius:2px;
+  background:color-mix(in srgb,var(--accent) 70%, transparent);
+}
+.ff-headline{
+  margin:.35em 0 .4em;
+  font:900 clamp(2.6rem, 6vw, 3.8rem)/1.05 var(--font-display);
+  letter-spacing:-.022em;
+}
+.ff-hero__lead{ margin:0; max-width:38ch; color:color-mix(in srgb,var(--muted) 70%, var(--ink) 15%); font-size:1.04rem; }
+.ff-hero__actions{ display:flex; flex-wrap:wrap; gap:14px; margin-top:28px; }
+.ff-stat-bar{
+  display:grid;
+  gap:16px;
+  grid-template-columns:repeat(auto-fit,minmax(160px,1fr));
+  margin-top:38px;
+}
+.ff-stat{
+  padding:18px 20px;
+  border-radius:18px;
+  background:color-mix(in srgb,var(--panel) 88%, transparent);
+  border:1px solid color-mix(in srgb,var(--border) 78%, transparent);
+  box-shadow:0 20px 32px rgba(3,10,24,.4);
+}
+.ff-stat dt{ margin:0; font-size:.78rem; letter-spacing:.16em; text-transform:uppercase; color:color-mix(in srgb,var(--muted) 80%, var(--ink) 10%); }
+.ff-stat dd{ margin:.35em 0 0; font:700 1.35rem/1.1 var(--font-display); }
+
+.ff-hero__media{ position:relative; justify-self:end; }
+.ff-card-stack{ position:relative; width:min(420px, 100%); }
+.ff-card-stack__layer{
+  position:relative;
+  padding:22px;
+  border-radius:26px;
+  background:linear-gradient(150deg, color-mix(in srgb,var(--card-2) 82%, transparent) 0%, color-mix(in srgb,var(--panelSoft) 82%, transparent) 100%);
+  border:1px solid color-mix(in srgb,var(--card-frame) 50%, transparent);
+  box-shadow:0 26px 48px rgba(3,10,24,.55);
+}
+.ff-card-stack__layer[data-layer="2"]{ position:absolute; inset:22px -32px auto 32px; transform:rotate(-6deg); opacity:.85; }
+.ff-card-stack__layer[data-layer="3"]{ position:absolute; inset:48px -54px auto 54px; transform:rotate(8deg); opacity:.65; }
+.ff-card-stack__layer img{ width:100%; border-radius:18px; box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--thumb-border) 65%, transparent); }
+.ff-card-stack__label{ margin-top:16px; font-size:.88rem; color:color-mix(in srgb,var(--muted) 75%, var(--ink) 10%); }
+
+.ff-section{ padding: clamp(56px, 9vw, 110px) 0; position:relative; }
+.ff-section--alt{ background:color-mix(in srgb,var(--panelSoft) 70%, transparent); }
+.ff-section__head{ display:grid; gap:12px; max-width:520px; margin-bottom:32px; }
+.ff-section__title{ margin:0; font:900 clamp(1.9rem,4vw,2.4rem)/1.08 var(--font-display); }
+.ff-section__intro{ margin:0; color:color-mix(in srgb,var(--muted) 75%, var(--ink) 12%); font-size:1.02rem; }
+
+.ff-feature-grid{ display:grid; gap:26px; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); }
+.ff-feature-card{
+  padding:26px;
+  border-radius:24px;
+  background:linear-gradient(160deg, color-mix(in srgb,var(--panel) 88%, transparent) 0%, color-mix(in srgb,var(--panelSoft) 82%, transparent) 100%);
+  border:1px solid color-mix(in srgb,var(--border) 80%, transparent);
+  box-shadow:0 22px 46px rgba(4,12,24,.45);
+  display:grid;
+  gap:16px;
+}
+.ff-feature-card h3{ margin:0; font:800 1.22rem/1.15 var(--font-display); }
+.ff-feature-card p{ margin:0; color:color-mix(in srgb,var(--muted) 78%, var(--ink) 12%); font-size:.98rem; }
+
+.ff-panel-grid{ display:grid; gap:28px; grid-template-columns:minmax(0,1.2fr) minmax(0,.8fr); align-items:start; }
+@media (max-width:960px){ .ff-panel-grid{ grid-template-columns:1fr; } }
+.ff-panel{
+  position:relative;
+  padding:30px;
+  border-radius:28px;
+  background:linear-gradient(155deg, color-mix(in srgb,var(--panel) 86%, transparent) 0%, color-mix(in srgb,var(--panelSoft) 86%, transparent) 100%);
+  border:1px solid color-mix(in srgb,var(--border) 78%, transparent);
+  box-shadow:0 28px 52px rgba(4,12,26,.5);
+  display:grid;
+  gap:22px;
+}
+.ff-panel h2{ margin:0; font:800 1.5rem/1.1 var(--font-display); }
+.ff-panel p{ margin:0; color:color-mix(in srgb,var(--muted) 75%, var(--ink) 10%); }
+.ff-panel .muted{ color:color-mix(in srgb,var(--muted) 82%, var(--ink) 8%); }
+
+.ff-feed{ list-style:none; margin:0; padding:0; display:grid; gap:14px; }
+.ff-feed .row{
+  display:grid;
+  grid-template-columns:auto 1fr;
+  gap:14px;
+  align-items:center;
+  padding:14px 16px;
+  border-radius:18px;
+  background:color-mix(in srgb,var(--panel) 88%, transparent);
+  border:1px solid color-mix(in srgb,var(--border) 82%, transparent);
+  box-shadow:0 16px 26px rgba(3,12,24,.42);
+  cursor:pointer;
+  transition:transform .18s ease, box-shadow .18s ease;
+}
+.ff-feed .row:hover{ transform:translateY(-3px); box-shadow:0 20px 32px rgba(3,12,24,.5); }
+.ff-feed .pg-muted{ color:color-mix(in srgb,var(--muted) 78%, var(--ink) 10%); font-size:.92rem; }
+
+.ff-step-grid{ display:grid; gap:24px; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); }
+.ff-step{
+  padding:24px;
+  border-radius:22px;
+  border:1px solid color-mix(in srgb,var(--border) 76%, transparent);
+  background:linear-gradient(150deg, color-mix(in srgb,var(--panelSoft) 82%, transparent) 0%, color-mix(in srgb,var(--panel) 80%, transparent) 100%);
+  box-shadow:0 18px 32px rgba(3,10,22,.45);
+}
+.ff-step h3{ margin:0; font:800 1.18rem/1.18 var(--font-display); }
+.ff-step p{ margin:.6em 0 0; color:color-mix(in srgb,var(--muted) 76%, var(--ink) 14%); font-size:.98rem; }
+
+.ff-cta{
+  padding: clamp(64px, 12vw, 120px) 0;
+  background:linear-gradient(160deg, rgba(125,240,178,.18) 0%, rgba(18,32,48,.92) 100%);
+}
+.ff-cta__inner{ display:grid; gap:24px; text-align:center; justify-items:center; }
+.ff-cta__inner h2{ margin:0; font:900 clamp(2.1rem,5vw,2.8rem)/1.08 var(--font-display); }
+.ff-cta__inner p{ margin:0; max-width:60ch; color:color-mix(in srgb,var(--muted) 75%, var(--ink) 12%); }
+.ff-cta__actions{ display:flex; gap:16px; flex-wrap:wrap; justify-content:center; margin-top:12px; }
+
+.ff-footer{
+  padding:36px 0 48px;
+  color:color-mix(in srgb,var(--muted) 78%, var(--ink) 12%);
+  border-top:1px solid color-mix(in srgb,var(--border) 70%, transparent);
+  margin-top:auto;
+}
+.ff-footer__inner{ display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:18px; }
+
+/* ---------- Inner Pages ---------- */
+.ff-page-hero{
+  position:relative;
+  padding: clamp(96px, 11vw, 150px) 0 clamp(44px, 8vw, 70px);
+  background:linear-gradient(145deg, rgba(124,195,255,.18) 0%, rgba(12,22,34,.95) 100%);
+  overflow:hidden;
+}
+.ff-page-hero::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at 82% 18%, rgba(125,240,178,.2), transparent 60%);
+  pointer-events:none;
+}
+.ff-page-hero__inner{ position:relative; display:grid; gap:32px; grid-template-columns:minmax(0,1.1fr) minmax(0,.9fr); align-items:end; }
+@media (max-width:960px){ .ff-page-hero__inner{ grid-template-columns:1fr; } }
+.ff-page-hero__title{ margin:0; font:900 clamp(2.2rem,5vw,3rem)/1.06 var(--font-display); }
+.ff-page-hero__lead{ margin:12px 0 0; color:color-mix(in srgb,var(--muted) 76%, var(--ink) 12%); max-width:56ch; }
+.ff-page-hero__meta{ display:flex; gap:16px; flex-wrap:wrap; }
+.ff-pill{
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  padding:.45rem .9rem;
+  border-radius:999px;
+  border:1px solid color-mix(in srgb,var(--border) 75%, transparent);
+  background:color-mix(in srgb,var(--panel) 85%, transparent);
+  font-weight:700;
+  font-size:.9rem;
+}
+
+.ff-page-content{ padding: clamp(40px, 7vw, 90px) 0 clamp(28px, 6vw, 60px); }
+.ff-page-grid{ display:grid; gap:34px; grid-template-columns:minmax(0,1.6fr) minmax(0,.9fr); align-items:start; }
+@media (max-width:1080px){ .ff-page-grid{ grid-template-columns:1fr; } }
+.ff-main-panel{ display:grid; gap:26px; }
+.ff-side-panel{ display:grid; gap:20px; }
+
+.ff-toolbar{ display:flex; flex-wrap:wrap; gap:16px; align-items:center; justify-content:space-between; }
+.ff-toolbar__group{ display:flex; gap:12px; flex-wrap:wrap; align-items:center; }
+.ff-input,
+.ff-select{
+  padding:.6rem .85rem;
+  border-radius:14px;
+  border:1px solid color-mix(in srgb,var(--border) 78%, transparent);
+  background:color-mix(in srgb,var(--panel) 86%, transparent);
+  color:var(--ink);
+  font:600 .95rem/1 var(--font-ui);
+}
+.ff-input::placeholder{ color:color-mix(in srgb,var(--muted) 78%, transparent); }
+.ff-input:focus,
+.ff-select:focus{ outline:none; box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 25%, transparent); }
+
+.ff-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:.45rem .85rem;
+  border-radius:14px;
+  border:1px solid color-mix(in srgb,var(--border) 78%, transparent);
+  background:color-mix(in srgb,var(--panelSoft) 84%, transparent);
+  font-weight:600;
+  font-size:.9rem;
+}
+
+.ff-grid{ display:grid; gap:24px; }
+.ff-grid-cards{ display:grid; gap:26px; grid-template-columns:repeat(auto-fit,minmax(320px,1fr)); }
+.ff-empty{ padding:48px; text-align:center; color:color-mix(in srgb,var(--muted) 80%, var(--ink) 12%); border-radius:20px; border:1px solid color-mix(in srgb,var(--border) 75%, transparent); background:color-mix(in srgb,var(--panelSoft) 80%, transparent); }
+
+.ff-list-compact{ list-style:none; margin:0; padding:0; display:grid; gap:12px; }
+.ff-list-compact li{
+  padding:14px 16px;
+  border-radius:16px;
+  border:1px solid color-mix(in srgb,var(--border) 78%, transparent);
+  background:color-mix(in srgb,var(--panel) 86%, transparent);
+  color:var(--ink);
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.ff-list-compact .meta{ color:color-mix(in srgb,var(--muted) 80%, var(--ink) 12%); font-size:.9rem; }
+
+.ff-toolbar .ff-button{ padding:.55rem .9rem; }
+
+@media (max-width:720px){
+  .ff-masthead__inner{ height:72px; gap:18px; }
+  .ff-nav{ gap:16px; }
+  .ff-panel{ padding:24px; border-radius:24px; }
+  .ff-panel-grid{ gap:22px; }
+  .ff-card-stack__layer[data-layer="2"]{ inset:18px -26px auto 26px; }
+  .ff-card-stack__layer[data-layer="3"]{ inset:38px -42px auto 42px; }
 }

--- a/assets/js/app-collection.js
+++ b/assets/js/app-collection.js
@@ -1,7 +1,7 @@
 // assets/js/app-collection.js
 // "My Frogs (Owned)" — restore mini header (Owned • Staked • Unclaimed Rewards)
 // Approve shows only when needed; Claim Rewards action; cards unchanged;
-// Meta shows "Staked Xd ago • Owned by You". Owned=Reservoir, Staked=controller.
+// Meta shows "Owned by You" / "Staked NNd ago by You". Owned=Reservoir, Staked=controller.
 
 (function(){
   'use strict';
@@ -174,9 +174,9 @@
     return rows.length? '<ul class="attr-list">'+rows.join('')+'</ul>' : '';
   }
   function metaLine(it){
-    if (!it.staked) return 'Not staked • Owned by You';
+    if (!it.staked) return 'Owned by You';
     var days = it.stakedTs ? timeAgoDays(it.stakedTs) : null;
-    return days!=null ? ('Staked '+days+'d ago • Owned by You') : 'Staked • Owned by You';
+    return days!=null ? ('Staked '+days+'d ago by You') : 'Staked by You';
   }
 
   function headerRoot(){

--- a/assets/js/frog-cards.js
+++ b/assets/js/frog-cards.js
@@ -8,40 +8,191 @@
   const CFG = window.FF_CFG || {};
   const CHAIN_ID = Number(CFG.CHAIN_ID || 1);
   const BASEPATH = (CFG.SOURCE_PATH || '').replace(/\/+$/,'');
-  const LEVEL_SECS = Math.max(1, Number(CFG.STAKE_LEVEL_SECONDS || 86400));
+  const LEVEL_SECS = Math.max(1, Number(CFG.STAKE_LEVEL_SECONDS || (30 * 86400)));
   const NO_HOVER_KEYS = new Set(['Trait','Frog','SpecialFrog']);
+  const CARD_LAYOUTS = ['classic'];
+  const CARD_LAYOUT_LABELS = {
+    classic: 'Classic'
+  };
 
   (function injectCSS(){
     if (document.getElementById('ff-frog-cards-css')) return;
     const css = `
-.frog-cards{ display:grid; gap:10px; }
-.frog-card{ padding:14px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
-.frog-card .row{ display:grid; grid-template-columns:auto 1fr; gap:12px; align-items:start; }
-.frog-card .thumb-wrap{ width:128px; min-width:128px; position:relative; } /* relative for GIF overlays */
-.frog-card .thumb, .frog-card canvas.frog-canvas{
-  width:128px; height:128px; min-width:128px; min-height:128px;
-  border-radius:10px; object-fit:contain; background:var(--panel-2); display:block;
+.frog-cards{ display:grid; gap:26px; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); }
+.frog-card{
+  position:relative;
+  padding:24px 22px 22px;
+  border-radius:22px;
+  background:color-mix(in srgb, var(--card-inner) 84%, var(--card));
+  border:1px solid color-mix(in srgb, var(--card-frame) 45%, transparent);
+  box-shadow:var(--card-shadow, 0 24px 50px rgba(0,0,0,.4));
+  overflow:hidden;
+  color:var(--ink);
+  --fc-muted: color-mix(in srgb, var(--muted) 70%, #ffffff 10%);
 }
-.frog-card .title{ margin:0 0 4px 0; font-weight:800; font-size:16px; }
-.frog-card .pill{ font-size:12px; padding:2px 8px; border:1px solid var(--border); border-radius:999px; vertical-align:middle; }
-.frog-card .pill.rk-legendary{ color:#f59e0b; border-color: color-mix(in srgb,#f59e0b 70%, var(--border)); }
-.frog-card .pill.rk-epic{ color:#a855f7; border-color: color-mix(in srgb,#a855f7 70%, var(--border)); }
-.frog-card .pill.rk-rare{ color:#38bdf8; border-color: color-mix(in srgb,#38bdf8 70%, var(--border)); }
-.frog-card .meta{ margin:0; color:#22c55e; } /* staked line in green */
-.frog-card .attr-bullets{ list-style:disc; margin:6px 0 0 18px; padding:0; }
-.frog-card .attr-bullets li{ font-size:12px; margin:2px 0; cursor:default; }
+.frog-card::before{
+  content:'';
+  position:absolute;
+  inset:0;
+  background:var(--card-foil, linear-gradient(135deg, rgba(255,255,255,.08), transparent 70%));
+  mix-blend-mode:screen;
+  opacity:.5;
+  pointer-events:none;
+}
+.frog-card::after{
+  content:'';
+  position:absolute;
+  inset:1px;
+  border-radius:20px;
+  background:color-mix(in srgb, var(--panelSoft) 78%, transparent);
+  opacity:.85;
+  pointer-events:none;
+}
+.frog-card .row{
+  position:relative;
+  z-index:1;
+  display:grid;
+  grid-template-columns:140px 1fr;
+  gap:18px;
+  align-items:start;
+}
+@media (max-width:620px){
+  .frog-card .row{ grid-template-columns:1fr; }
+  .frog-card .thumb-wrap{ justify-self:center; }
+}
+.frog-card .thumb-wrap{
+  width:140px;
+  min-width:140px;
+  height:140px;
+  position:relative;
+  border-radius:18px;
+  padding:6px;
+  background:linear-gradient(140deg, color-mix(in srgb, var(--card-2) 85%, transparent) 0%, color-mix(in srgb, var(--panelSoft) 80%, transparent) 100%);
+  box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--thumb-border, var(--border)) 65%, transparent);
+}
+.frog-card .thumb,
+.frog-card canvas.frog-canvas{
+  width:128px;
+  height:128px;
+  min-width:128px;
+  min-height:128px;
+  border-radius:14px;
+  object-fit:contain;
+  background:color-mix(in srgb, var(--panelSoft) 85%, transparent);
+  display:block;
+}
+.frog-card .title{
+  margin:0 0 6px 0;
+  font:800 18px/1.1 var(--font-display);
+  letter-spacing:-.01em;
+}
+.frog-card .pill{
+  font-size:12px;
+  padding:3px 10px;
+  border:1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  border-radius:999px;
+  background:linear-gradient(135deg, color-mix(in srgb, var(--accent) 18%, transparent) 0%, color-mix(in srgb, var(--accent) 6%, transparent) 100%);
+  color:var(--accent);
+  font-weight:700;
+  letter-spacing:.03em;
+  text-transform:uppercase;
+}
+.frog-card .pill.rk-legendary{ color:#facc15; border-color:color-mix(in srgb,#facc15 60%, transparent); }
+.frog-card .pill.rk-epic{ color:#a855f7; border-color:color-mix(in srgb,#a855f7 60%, transparent); }
+.frog-card .pill.rk-rare{ color:#38bdf8; border-color:color-mix(in srgb,#38bdf8 60%, transparent); }
+.frog-card .meta{
+  margin:0;
+  color:var(--fc-muted);
+  font-size:13px;
+  display:grid;
+  gap:4px;
+}
+.frog-card .meta .staked-flag{ color:#22c55e; font-weight:700; }
+.frog-card .meta .ago-line{ color:color-mix(in srgb, var(--fc-muted) 85%, #ffffff 5%); font-weight:600; }
+.frog-card .attr-bullets{
+  list-style:none;
+  margin:12px 0 0;
+  padding:0;
+  display:grid;
+  gap:8px;
+}
+.frog-card .attr-bullets li{
+  font-size:13px;
+  padding:9px 11px;
+  border-radius:12px;
+  background:color-mix(in srgb, var(--panelSoft) 80%, transparent);
+  border:1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  color:color-mix(in srgb, var(--ink) 82%, var(--muted));
+  display:flex;
+  gap:6px;
+  align-items:center;
+  transition:transform .2s ease, box-shadow .2s ease;
+}
+.frog-card .attr-bullets li b{
+  font-size:12px;
+  letter-spacing:.02em;
+}
 .frog-card .attr-bullets li[data-hoverable="1"]{ cursor:pointer; }
-.frog-card .actions{ display:flex; gap:8px; flex-wrap:wrap; margin-top:10px; }
-.frog-card .btn{ font-family:var(--font-ui); border:1px solid var(--border); background:transparent; color:inherit; border-radius:8px; padding:6px 10px; font-weight:700; font-size:12px; line-height:1; }
+.frog-card .attr-bullets li[data-hoverable="1"]:hover{
+  transform:translate(-4px,-6px);
+  box-shadow:0 16px 24px rgba(0,0,0,.35);
+}
+.frog-card .actions{
+  position:relative;
+  z-index:1;
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+  margin-top:18px;
+}
+.frog-card .btn{
+  font-family:var(--font-ui);
+  border:1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+  background:linear-gradient(135deg, color-mix(in srgb, var(--card-2) 75%, transparent) 0%, color-mix(in srgb, var(--panelSoft) 75%, transparent) 100%);
+  color:var(--ink);
+  border-radius:12px;
+  padding:7px 12px;
+  font-weight:700;
+  font-size:12px;
+  line-height:1;
+}
 .frog-card .btn:disabled{ opacity:.5; cursor:not-allowed; }
-.fc-level{ display:grid; grid-template-columns:auto 1fr auto; gap:8px; align-items:center; margin:4px 0 0; }
-.fc-level .lab{ font-size:12px; color:var(--muted); }
-.fc-level .val{ font-size:12px; font-weight:700; }
-.fc-level .bar{ height:6px; border:1px solid var(--border); border-radius:999px; background:color-mix(in srgb, var(--panel) 90%, transparent); overflow:hidden; }
-.fc-level .bar > i{ display:block; height:100%; width:0%; background:linear-gradient(90deg, #16a34a, #4ade80); }
-    `;
+.fc-level{
+  position:relative;
+  z-index:1;
+  display:grid;
+  grid-template-columns:auto 1fr auto;
+  gap:10px;
+  align-items:center;
+  margin:12px 0 0;
+}
+.fc-level .lab{ font-size:12px; color:var(--fc-muted); text-transform:uppercase; letter-spacing:.06em; }
+.fc-level .val{ font-size:12px; font-weight:700; color:var(--ink); }
+.fc-level .bar{
+  height:8px;
+  border:1px solid color-mix(in srgb, var(--card-frame) 40%, var(--border));
+  border-radius:999px;
+  background:color-mix(in srgb, var(--panelSoft) 86%, transparent);
+  overflow:hidden;
+}
+.fc-level .bar > i{
+  display:block;
+  height:100%;
+  width:0%;
+  background:linear-gradient(90deg, color-mix(in srgb, var(--accent) 80%, transparent), color-mix(in srgb, var(--accent) 35%, transparent));
+}
+`;
     const s = document.createElement('style');
-    s.id='ff-frog-cards-css'; s.textContent=css; document.head.appendChild(s);
+    s.id = 'ff-frog-cards-css';
+    s.textContent = css;
+    document.head.appendChild(s);
+  })();
+
+  (function ensureLayoutAttribute(){
+    const root = document.documentElement;
+    if (root && !root.getAttribute('data-card-layout')){
+      root.setAttribute('data-card-layout', 'classic');
+    }
   })();
 
   function imgFor(id){ return `${BASEPATH}/frog/${id}.png`; }
@@ -60,6 +211,48 @@
     const h=Math.floor((s%86400)/3600); if(h>=1) return h+'h ago';
     const m=Math.floor((s%3600)/60); if(m>=1) return m+'m ago';
     return s+'s ago';
+  }
+  function escapeHtml(str){
+    return String(str)
+      .replace(/&/g,'&amp;')
+      .replace(/</g,'&lt;')
+      .replace(/>/g,'&gt;')
+      .replace(/"/g,'&quot;')
+      .replace(/'/g,'&#39;');
+  }
+  function attrEscape(str){
+    return String(str).replace(/"/g,'&quot;');
+  }
+  function shortAddr(addr){
+    if(!addr||typeof addr!=='string') return '—';
+    const a = addr.trim();
+    if (!a) return '—';
+    if(a.length<=10) return a;
+    return a.slice(0,6)+'…'+a.slice(-4);
+  }
+  function ownerLabelFor(it){
+    if (it == null || typeof it !== 'object') return 'Unknown';
+    if (it.ownerLabel) return escapeHtml(it.ownerLabel);
+    if (it.ownerYou) return 'You';
+    if (it.ownerShort && it.ownerShort !== '—') return escapeHtml(it.ownerShort);
+    if (it.owner) return escapeHtml(shortAddr(it.owner));
+    if (it.holder) return escapeHtml(shortAddr(it.holder));
+    return 'Unknown';
+  }
+  function attrsFromMeta(meta){
+    const arr = meta && Array.isArray(meta.attributes) ? meta.attributes : null;
+    if (!arr || !arr.length) return null;
+    const out = [];
+    for (let i = 0; i < arr.length; i++){
+      const row = arr[i] || {};
+      const keyRaw = row.key ?? row.trait_type ?? row.traitType ?? row.type ?? null;
+      const valRaw = row.value ?? row.trait_value ?? row.traitValue ?? null;
+      const key = keyRaw != null ? String(keyRaw).trim() : '';
+      const val = valRaw != null ? String(valRaw).trim() : '';
+      if (!key || !val) continue;
+      out.push({ key, value: val });
+    }
+    return out.length ? out : null;
   }
   function levelInfo(sinceMs, secsPerLevel){
     if (!sinceMs) return { level:0, pct:0 };
@@ -81,15 +274,16 @@
     if (rank==null) return '';
     const t=tierFor(rank, tiers);
     const cls = t==='legendary'?'rk-legendary':t==='epic'?'rk-epic':t==='rare'?'rk-rare':'';
-    return ` <span class="pill ${cls}">Rank #${rank}</span>`;
+    return ` <span class="pill ${cls}">♦ #${rank}</span>`;
   }
   function attrsHTML(attrs, max=4){
     if (!Array.isArray(attrs)||!attrs.length) return '';
     const rows=[];
     for (let i=0;i<attrs.length;i++){
       const a = attrs[i]; if(!a.key||a.value==null) continue;
-      const hoverable = NO_HOVER_KEYS.has(a.key) ? '0' : '1';
-      rows.push(`<li data-attr-key="${String(a.key)}" data-hoverable="${hoverable}"><b>${a.key}:</b> ${String(a.value)}</li>`);
+      const keyStr = String(a.key);
+      const hoverable = NO_HOVER_KEYS.has(keyStr) ? '0' : '1';
+      rows.push(`<li data-attr-key="${attrEscape(keyStr)}" data-hoverable="${hoverable}"><b>${escapeHtml(keyStr)}:</b> ${escapeHtml(String(a.value))}</li>`);
       if(rows.length>=max) break;
     }
     return rows.length? '<ul class="attr-bullets">'+rows.join('')+'</ul>' : '';
@@ -146,11 +340,13 @@
     }
 
   function metaLineDefault(it){
+    const ownerLabel = ownerLabelFor(it);
     if (it.staked){
-      const ago = it.sinceMs ? fmtAgo(it.sinceMs) : null;
-      return (ago ? `Staked ${ago}` : 'Staked') + ' • Owned by You';
+      const agoRaw = it.sinceMs ? fmtAgo(it.sinceMs) : null;
+      const agoHtml = agoRaw ? `<span class="ago-line">${escapeHtml(agoRaw)}</span>` : '';
+      return `<span class="staked-flag">Staked</span> by ${ownerLabel}${agoHtml}`;
     }
-    return 'Not staked • Owned by You';
+    return 'Owned by ' + ownerLabel;
   }
 
   function levelRowHTML(it, secsPerLevel){
@@ -184,16 +380,16 @@
           <div class="meta">${metaLine}</div>
           ${levelRowHTML(item, secsPer)}
           ${attrs}
-          ${options.showActions ? `
-            <div class="actions">
-              <button class="btn" data-act="${item.staked ? 'unstake' : 'stake'}">${item.staked ? 'Unstake' : 'Stake'}</button>
-              <button class="btn" data-act="transfer" ${disableTransfer ? 'disabled title="Transfer disabled while staked"' : ''}>Transfer</button>
-              ${options.linkEtherscan !== false ? `<a class="btn" href="${(options.etherscanForId||etherscanFor)(item.id)}" target="_blank" rel="noopener">Etherscan</a>`:''}
-              ${options.linkOriginal !== false ? `<a class="btn" href="${(options.imgForId||imgFor)(item.id)}" target="_blank" rel="noopener">Original</a>`:''}
-            </div>
-          `:``}
         </div>
       </div>
+      ${options.showActions ? `
+        <div class="actions">
+          <button class="btn" data-act="${item.staked ? 'unstake' : 'stake'}">${item.staked ? 'Unstake' : 'Stake'}</button>
+          <button class="btn" data-act="transfer" ${disableTransfer ? 'disabled title="Transfer disabled while staked"' : ''}>Transfer</button>
+          ${options.linkEtherscan !== false ? `<a class="btn" href="${(options.etherscanForId||etherscanFor)(item.id)}" target="_blank" rel="noopener">Etherscan</a>`:''}
+          ${options.linkOriginal !== false ? `<a class="btn" href="${(options.imgForId||imgFor)(item.id)}" target="_blank" rel="noopener">Original</a>`:''}
+        </div>
+      `:``}
     `;
 
     // hover wiring (per attribute)
@@ -242,9 +438,18 @@
         id: Number(x.id),
         staked: !!x.staked,
         sinceMs: Number(x.sinceMs||0) || null,
-        attrs: Array.isArray(x.attrs)? x.attrs : [],
+        attrs: (()=>{
+          const metaAttrs = attrsFromMeta(x.metaRaw || null);
+          if (metaAttrs) return metaAttrs;
+          return Array.isArray(x.attrs)? x.attrs : [];
+        })(),
         rank: (x.rank==null? null : Number(x.rank)),
-        metaRaw: x.metaRaw || null
+        metaRaw: x.metaRaw || null,
+        owner: x.owner || null,
+        ownerShort: x.ownerShort || null,
+        ownerYou: !!x.ownerYou,
+        holder: x.holder || null,
+        ownerLabel: x.ownerLabel || null
       };
     }
     return null;
@@ -257,7 +462,15 @@
     return null;
   }
 
+  function normalizeLayoutId(id){
+    if (!id || typeof id !== 'string') return 'classic';
+    const lower = id.toLowerCase();
+    return CARD_LAYOUTS.indexOf(lower) >= 0 ? lower : 'classic';
+  }
+
   window.FF = window.FF || {};
+  window.FF.shortAddress = shortAddr;
+  window.FF.formatOwnerLine = metaLineDefault;
   window.FF.buildFrogCard = buildCard;
   window.FF.renderFrogCards = function renderFrogCards(container, frogs, options){
     const root = resolveContainer(container);
@@ -275,5 +488,22 @@
     for (const it of rows){
       root.appendChild(buildCard(it, opts));
     }
+  };
+  window.FF.setCardLayout = function setCardLayout(id){
+    const root = document.documentElement;
+    if (!root) return;
+    root.setAttribute('data-card-layout', normalizeLayoutId(id));
+  };
+  window.FF.getCardLayout = function getCardLayout(){
+    const root = document.documentElement;
+    if (!root) return 'classic';
+    return normalizeLayoutId(root.getAttribute('data-card-layout'));
+  };
+  window.FF.availableCardLayouts = function availableCardLayouts(){
+    return CARD_LAYOUTS.map((id)=>({ id, label: CARD_LAYOUT_LABELS[id] || id }));
+  };
+  window.FF.cardLayoutLabel = function cardLayoutLabel(id){
+    const key = normalizeLayoutId(id);
+    return CARD_LAYOUT_LABELS[key] || key;
   };
 })();

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -90,12 +90,16 @@
     function setState({ staked, owner }){
       current.staked = !!staked; current.owner = owner || '';
       // default line, then override below
-      fmLine && (fmLine.textContent = `${staked ? 'Staked' : 'Not staked'} • Owned by ${ownerLabel(owner)}`);
+      if (fmLine){
+        fmLine.textContent = staked
+          ? `Staked by ${ownerLabel(owner)}`
+          : `Owned by ${ownerLabel(owner)}`;
+      }
 
-      // If staked and we know when, render 'Staked NNd ago • Owned by ...'
+      // If staked and we know when, render 'Staked … ago by …'
       if (staked && current?.sinceMs && !isNaN(current.sinceMs)){
         const days = Math.floor((Date.now() - Number(current.sinceMs)) / 86400000);
-        fmLine && (fmLine.textContent = `Staked ${days}d ago • Owned by ${ownerLabel(owner)}`);
+        fmLine && (fmLine.textContent = `Staked ${days}d ago by ${ownerLabel(owner)}`);
       }
 
       fmOwner && (fmOwner.textContent = owner || '—');
@@ -118,7 +122,7 @@
       if (!current.staked || !fmLine) return;
 
       if (current.sinceMs && !isNaN(current.sinceMs)){
-        fmLine.textContent = `Staked ${fmtAgoMs(Date.now() - Number(current.sinceMs))} • Owned by ${ownerLabel(owner)}`;
+        fmLine.textContent = `Staked ${fmtAgoMs(Date.now() - Number(current.sinceMs))} by ${ownerLabel(owner)}`;
         return;
       }
 
@@ -135,12 +139,12 @@
           }
           if (ms){
             current.sinceMs = ms;
-            fmLine.textContent = `Staked ${fmtAgoMs(Date.now() - ms)} • Owned by ${ownerLabel(owner)}`;
+            fmLine.textContent = `Staked ${fmtAgoMs(Date.now() - ms)} by ${ownerLabel(owner)}`;
             return;
           }
         }
       }catch{}
-      fmLine.textContent = `Staked • Owned by ${ownerLabel(owner)}`;
+      fmLine.textContent = `Staked by ${ownerLabel(owner)}`;
     }
 
     // ---------- metadata/attributes ----------

--- a/assets/js/mutate.js
+++ b/assets/js/mutate.js
@@ -39,7 +39,10 @@
 
   function setInfo(id, data) {
     els.title.textContent = `Frog #${id}`;
-    els.status.textContent = `${data.staked ? 'Staked' : 'Not staked'} • ${data.ownerYou ? 'Owned by You' : 'Owner ' + short(data.owner)}`;
+    const ownerLabel = data.ownerYou ? 'You' : (data.owner ? short(data.owner) : '—');
+    els.status.textContent = data.staked
+      ? `Staked by ${ownerLabel}`
+      : `Owned by ${ownerLabel}`;
 
     // Traits list
     els.traits.innerHTML = '';

--- a/assets/js/owned-panel.js
+++ b/assets/js/owned-panel.js
@@ -32,42 +32,39 @@
   (function injectCSS(){
     if (document.getElementById('owned-clean-css')) return;
     const css = `
-#ownedCard .oh-wrap{margin-bottom:10px}
-#ownedCard .oh-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
-#ownedCard .oh-mini{font-size:11px;line-height:1}
+#ownedCard .oh-wrap{margin-bottom:16px}
+#ownedCard .oh-row{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+#ownedCard .oh-mini{font-size:12px;line-height:1}
 #ownedCard .oh-spacer{flex:1}
 #ownedCard .oh-muted{color:var(--muted)}
-#ownedCard .oh-btn{font-family:var(--font-ui);border:1px solid var(--border);background:transparent;color:inherit;border-radius:8px;padding:6px 10px;font-weight:700;font-size:12px;line-height:1;display:inline-flex;align-items:center;gap:6px;text-decoration:none;letter-spacing:.01em;transition:background .15s,border-color .15s,color .15s,transform .05s}
+#ownedCard .oh-btn{display:inline-flex;align-items:center;gap:8px;padding:.55rem .95rem;border-radius:12px;border:1px solid color-mix(in srgb,var(--accent) 35%, transparent);background:transparent;color:var(--ink);font-weight:700;font-size:.9rem;letter-spacing:.01em;transition:background .15s ease,border-color .15s ease,color .15s ease,transform .05s ease}
 #ownedCard .oh-btn:active{transform:translateY(1px)}
-#ownedCard .oh-btn:hover{background: color-mix(in srgb,#22c55e 14%,var(--panel));border-color: color-mix(in srgb,#22c55e 80%,var(--border));color: color-mix(in srgb,#ffffff 85%,#22c55e)}
-#ownedCard .pg-card-head .btn:hover{background: color-mix(in srgb,#22c55e 14%,var(--panel));border-color: color-mix(in srgb,#22c55e 80%,var(--border));color: color-mix(in srgb,#ffffff 85%,#22c55e)}
-#ownedCard .pg-card-head .btn.btn-connected{background: color-mix(in srgb,#22c55e 18%,var(--panel));border-color: color-mix(in srgb,#22c55e 85%,var(--border));color: color-mix(in srgb,#ffffff 90%,#22c55e)}
+#ownedCard .oh-btn:hover{background:color-mix(in srgb,var(--accent) 18%, transparent);border-color:color-mix(in srgb,var(--accent) 55%, transparent)}
+#ownedCard .ff-toolbar .ff-button.btn-connected{background:linear-gradient(135deg,color-mix(in srgb,var(--accent) 80%, transparent) 0%,color-mix(in srgb,var(--accent) 45%, transparent) 100%);color:var(--accent-ink);border-color:color-mix(in srgb,var(--accent) 70%, transparent)}
+#ownedCard .ff-toolbar .ff-button.btn-connected.address-chip{max-width:40ch;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-family:var(--font-ui)}
 #ownedGrid{overflow:auto;-webkit-overflow-scrolling:touch;padding-right:4px}
 @media (hover:hover){
   #ownedGrid::-webkit-scrollbar{width:8px}
   #ownedGrid::-webkit-scrollbar-thumb{background: color-mix(in srgb,var(--muted) 35%, transparent); border-radius:8px}
 }
-#ownedCard .attr-bullets{list-style:disc;margin:6px 0 0 18px;padding:0}
-#ownedCard .attr-bullets li{font-size:12px;margin:2px 0}
+#ownedCard .attr-bullets{list-style:none;margin:10px 0 0 0;padding:0;display:grid;gap:8px}
+#ownedCard .attr-bullets li{font-size:13px;padding:8px 10px;border-radius:10px;background:color-mix(in srgb,var(--panelSoft) 80%, transparent);border:1px solid color-mix(in srgb,var(--border) 78%, transparent)}
 
 /* Address label */
 #ownedCard .address-chip{
-  font-family: var(--font-ui);
-  border: 1px solid var(--border);
-  background: transparent;
-  color: var(--muted);
-  border-radius: 8px;
-  padding: 6px 10px;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  max-width: 40ch;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  cursor: default;
+  font-family:var(--font-ui);
+  border-radius:12px;
+  padding:.55rem .95rem;
+  border:1px solid color-mix(in srgb,var(--accent) 38%, transparent);
+  background:transparent;
+  color:color-mix(in srgb,var(--muted) 70%, var(--ink) 20%);
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  max-width:40ch;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
 }
 
 /* Owned modal */
@@ -384,10 +381,10 @@
       const attrs = Array.isArray(j?.attributes)
         ? j.attributes.map(a=>({ key:a?.key||a?.trait_type||'', value:(a?.value ?? a?.trait_value ?? '') }))
         : [];
-      const out = { id, attrs };
+      const out = { id, attrs, metaRaw: j };
       META.set(id,out); return out;
     }catch{
-      const out={ id, attrs:[] }; META.set(id,out); return out;
+      const out={ id, attrs:[], metaRaw:null }; META.set(id,out); return out;
     }
   }
   async function loadMetaBatch(ids){
@@ -444,13 +441,17 @@
 
   // --- Height sync with left panel ---
   function syncHeights(){
-    if (window.matchMedia('(max-width: 960px)').matches){ $('#ownedCard').style.height=''; $('#ownedGrid').style.maxHeight=''; return; }
-    const cards=document.querySelectorAll('.page-grid > .pg-card'); if(cards.length<2) return;
-    const left=cards[0], right=$('#ownedCard'); if(!left||!right) return;
+    const right=$('#ownedCard');
+    if (!right) return;
+    if (window.matchMedia('(max-width: 960px)').matches){ right.style.height=''; $('#ownedGrid').style.maxHeight=''; return; }
+    const cards=document.querySelectorAll('.ff-main-panel > .ff-panel');
+    if(cards.length<2) return;
+    const left=cards[0];
+    if(!left) return;
     right.style.height=left.offsetHeight+'px';
-    const header=right.querySelector('.oh-wrap'); const headerH=header?header.offsetHeight+10:0;
-    const pad=20; const maxH=left.offsetHeight-headerH-pad;
-    const grid=$('#ownedGrid'); if(grid) grid.style.maxHeight=Math.max(160,maxH)+'px';
+    const header=right.querySelector('.oh-wrap'); const headerH=header?header.offsetHeight+14:0;
+    const pad=28; const maxH=left.offsetHeight-headerH-pad;
+    const grid=$('#ownedGrid'); if(grid) grid.style.maxHeight=Math.max(200,maxH)+'px';
   }
   window.addEventListener('resize',()=> setTimeout(syncHeights,50));
 
@@ -604,53 +605,68 @@
   }
 
   // --- Cards ---
-  function attrsHTML(attrs, max=4){
-    if (!Array.isArray(attrs)||!attrs.length) return '';
-    const rows=[]; for (const a of attrs){ if(!a.key||a.value==null) continue; rows.push('<li><b>'+a.key+':</b> '+String(a.value)+'</li>'); if(rows.length>=max) break; }
-    return rows.length? '<ul class="attr-bullets">'+rows.join('')+'</ul>' : '';
+  function shortAddrLocal(a){
+    try{
+      if (window.FF && typeof window.FF.shortAddress === 'function'){
+        return window.FF.shortAddress(a);
+      }
+    }catch(_){ }
+    if (!a || typeof a !== 'string') return '—';
+    const t = a.trim();
+    if (!t) return '—';
+    if (t.length <= 10) return t;
+    return t.slice(0,6)+'…'+t.slice(-4);
   }
-  function fmtMeta(it){
+  function formatMetaLineForOwned(it){
+    try{
+      if (window.FF && typeof window.FF.formatOwnerLine === 'function'){
+        return window.FF.formatOwnerLine(it);
+      }
+    }catch(_){ }
+    const ownerLabelRaw = it.ownerYou ? 'You' : shortAddrLocal(it.owner);
+    const ownerLabel = ownerLabelRaw && ownerLabelRaw !== '—' ? ownerLabelRaw : 'Unknown';
     if (it.staked){
       const ago = it.sinceMs ? fmtAgo(it.sinceMs) : null;
-      return ago
-        ? ('<span class="staked-flag">Staked '+ago+'</span> • Owned by You')
-        : '<span class="staked-flag">Staked</span> • Owned by You';
+      const agoHtml = ago ? (' ' + ago) : '';
+      return '<span class="staked-flag">Staked' + agoHtml + ' by ' + ownerLabel + '</span>';
     }
-    return 'Not staked • Owned by You';
+    return 'Owned by ' + ownerLabel;
   }
-  function wireCardActions(scope,it){
-    scope.querySelectorAll('button[data-act]').forEach(btn=>{
-      btn.addEventListener('click', async ()=>{
-        const act = btn.getAttribute('data-act');
-        try{
-          const a = addr || await getConnectedAddress();
-          if (!a) { toast('Connect wallet first'); return; }
-
-          if (act==='stake'){
-            const approved = await checkApproved(a);
-            if (!approved){
-              const stakedIds = await getStakedIds(a).catch(()=>[]);
-              const rewardsRaw = await getRewards(a).catch(()=>null);
-              openApprovePanel(a, { approved:false, staked: stakedIds.length, rewards: rewardsRaw });
-            }else{
-              openStakePanel(a, it.id);
-            }
-          }else if (act==='unstake'){
-            openUnstakePanel(a, it.id);
-          }else if (act==='transfer'){
-            if (it.staked){ toast('This frog is staked. Unstake before transferring.'); return; }
-            openTransferPanel(a, it.id);
-          }
-        }catch{ toast('Action failed'); }
-      });
-    });
+  async function handleStake(id){
+    try{
+      const a = addr || await getConnectedAddress();
+      if (!a){ toast('Connect wallet first'); return; }
+      const approved = await checkApproved(a);
+      if (!approved){
+        const stakedIds = await getStakedIds(a).catch(()=>[]);
+        const rewardsRaw = await getRewards(a).catch(()=>null);
+        openApprovePanel(a, { approved:false, staked: stakedIds.length, rewards: rewardsRaw });
+      }else{
+        openStakePanel(a, id);
+      }
+    }catch{ toast('Action failed'); }
+  }
+  async function handleUnstake(id){
+    try{
+      const a = addr || await getConnectedAddress();
+      if (!a){ toast('Connect wallet first'); return; }
+      openUnstakePanel(a, id);
+    }catch{ toast('Action failed'); }
+  }
+  async function handleTransfer(id){
+    try{
+      const a = addr || await getConnectedAddress();
+      if (!a){ toast('Connect wallet first'); return; }
+      const target = items.find(x=>x.id===id);
+      if (target && target.staked){ toast('This frog is staked. Unstake before transferring.'); return; }
+      openTransferPanel(a, id);
+    }catch{ toast('Action failed'); }
   }
 
   function renderCards(){
     const root = document.querySelector('#ownedGrid');
     if (!root) return;
 
-    // keep list sorted even after optimistic updates
     items.sort(compareByRarity);
 
     root.innerHTML = '';
@@ -664,38 +680,34 @@
 
     updateHeaderOwned();
 
-    items.forEach(it => {
-      const card = document.createElement('article');
-      card.className = 'frog-card';
-      card.setAttribute('data-token-id', String(it.id));
-      if (it.staked) card.setAttribute('data-staked','1');
+    const ownerAddr = addr || null;
+    const ownerShort = ownerAddr ? shortAddrLocal(ownerAddr) : null;
+    const frogs = items.map(it => ({
+      id: it.id,
+      rank: it.rank,
+      attrs: it.attrs,
+      staked: it.staked,
+      sinceMs: it.sinceMs,
+      metaRaw: it.metaRaw,
+      owner: ownerAddr,
+      ownerShort: ownerShort,
+      ownerYou: !!ownerAddr,
+      holder: ownerAddr
+    }));
 
-      const r = Number(it.rank);
-      const hasRank = Number.isFinite(r);
-      const tier = hasRank ? rankTier(r) : 'common';
-      const rankPill = hasRank
-        ? ` <span class="rank-pill rank-${tier}">#${r}</span>`
-        : '';
-
-      const attrs = attrsHTML(it.attrs, 4);
-      const disabledAttrs = it.staked ? ' disabled aria-disabled="true" title="Unstake before transferring"' : '';
-
-      card.innerHTML = [
-        `<img class="thumb" src="${imgFor(it.id)}" alt="${it.id}">`,
-        `<h4 class="title">Frog #${it.id}${rankPill}</h4>`,
-        `<div class="meta">${fmtMeta(it)}</div>`,
-        attrs,
-        `<div class="actions">
-           <button class="btn btn-outline-gray" data-act="${it.staked ? 'unstake' : 'stake'}">${it.staked ? 'Unstake' : 'Stake'}</button>
-           <button class="btn btn-outline-gray ${it.staked ? 'btn-disabled' : ''}" data-act="transfer"${disabledAttrs}>Transfer</button>
-           <a class="btn btn-outline-gray" href="${etherscanToken(it.id)}" target="_blank" rel="noopener">Etherscan</a>
-           <a class="btn btn-outline-gray" href="${imgFor(it.id)}" target="_blank" rel="noopener">Original</a>
-         </div>`
-      ].join('');
-
-      root.appendChild(card);
-      wireCardActions(card, it);
-    });
+    if (window.FF && typeof window.FF.renderFrogCards === 'function'){
+      window.FF.renderFrogCards(root, frogs, {
+        showActions: true,
+        rarityTiers: CFG.RARITY_TIERS,
+        metaLine: formatMetaLineForOwned,
+        onStake: handleStake,
+        onUnstake: handleUnstake,
+        onTransfer: handleTransfer,
+        levelSeconds: Number(CFG.STAKE_LEVEL_SECONDS || (30 * 86400))
+      });
+    }else{
+      root.innerHTML = '<div class="pg-muted">Frog cards unavailable.</div>';
+    }
 
     syncHeights();
   }
@@ -750,7 +762,8 @@
           attrs: m.attrs,
           staked: stakedIds.includes(m.id),
           sinceMs: null,
-          rank: Number.isFinite(rkNum) ? rkNum : undefined
+          rank: Number.isFinite(rkNum) ? rkNum : undefined,
+          metaRaw: m.metaRaw || null
         };
       });
 
@@ -791,7 +804,8 @@
                 id:m.id, attrs:m.attrs,
                 staked: stakedIds.includes(m.id),
                 sinceMs:null,
-                rank: Number.isFinite(rkNum) ? rkNum : undefined
+                rank: Number.isFinite(rkNum) ? rkNum : undefined,
+                metaRaw: m.metaRaw || null
               };
             });
           items = items.concat(more);

--- a/assets/js/owned.js
+++ b/assets/js/owned.js
@@ -265,7 +265,7 @@
     clearList();
     const ids = ST.cache.ownedIds || [];
     if (!ids.length){ setStatus('No owned frogs in this wallet for this collection.'); return; }
-    ids.forEach(id=> ul.appendChild(liCard(id, 'Not staked • Owned by You', ST.addr, false)));
+    ids.forEach(id=> ul.appendChild(liCard(id, 'Owned by You', ST.addr, false)));
     setStatus(`Showing ${ids.length.toLocaleString()} owned frog(s). Scroll for more.`);
   }
 
@@ -275,7 +275,8 @@
     if (!rows.length){ setStatus('No frogs from this wallet are currently staked.'); return; }
     rows.forEach(r=>{
       const sinceMs = r.since ? r.since.getTime() : null;
-      const info = r.since ? `Staked ${fmtAgoMs(Date.now()-sinceMs)} • Owned by You` : 'Staked • Owned by You';
+      const agoLabel = sinceMs ? fmtAgoMs(Date.now()-sinceMs) : null;
+      const info = agoLabel ? `Staked ${agoLabel} by You` : 'Staked by You';
       ul.appendChild(liCard(r.id, info, ST.addr, true, sinceMs));
     });
     setStatus(`Showing ${rows.length} staked frog(s). Scroll for more.`);

--- a/assets/js/pond.js
+++ b/assets/js/pond.js
@@ -265,11 +265,13 @@
 
         // Middle: text block
         const mid = mk('div');
+        const sinceLabel = fmtAgo(r.since);
+        const sinceText = sinceLabel ? ' ' + sinceLabel : '';
         mid.innerHTML =
           `<div style="display:flex;align-items:center;gap:8px;">
              <b>Frog #${r.id}</b> ${pillRank(rank)}
            </div>
-           <div class="muted">Staked ${fmtAgo(r.since)} • Owned by ${r.staker ? shorten(r.staker) : '—'}</div>`;
+           <div class="muted">Staked${sinceText} by ${r.staker ? shorten(r.staker) : '—'}</div>`;
         li.appendChild(mid);
 
         ul.appendChild(li);

--- a/assets/js/rarity-page.js
+++ b/assets/js/rarity-page.js
@@ -1,355 +1,960 @@
-// assets/js/rarity-page.js
-// Rarity list that matches dashboard card visuals (rank pill tiers, staked line),
-// and uses the same 128×128 DOM layering from frog-renderer.js
+// assets/js/rarity-page.js — vanilla ES5-compatible rarity loader used by
+// rarity.html. This version intentionally avoids optional chaining, default
+// parameters, and other newer syntax so that the cards render in older
+// browsers.
 
-(function(FF = window.FF || {}, CFG = window.FF_CFG || {}) {
+(function(global){
   'use strict';
 
-  // ---------- DOM ----------
-  const GRID       = document.getElementById('rarityGrid');
-  const BTN_MORE   = document.getElementById('btnMore');
-  const BTN_RANK   = document.getElementById('btnSortRank');
-  const BTN_SCORE  = document.getElementById('btnSortScore');
-  const FIND_INPUT = document.getElementById('raritySearchId');
-  const BTN_GO     = document.getElementById('btnGo');
+  var FF  = global.FF     || {};
+  var CFG = global.FF_CFG || {};
+
+  var PAGE_CFG = global.FF_RARITY_PAGE_CONFIG || {};
+  try { delete global.FF_RARITY_PAGE_CONFIG; } catch (errCfg) {}
+
+  var GRID       = document.getElementById('rarityGrid');
+  var BTN_MORE   = document.getElementById('btnMore');
+  var BTN_RANK   = document.getElementById('btnSortRank');
+  var BTN_SCORE  = document.getElementById('btnSortScore');
+  var FIND_INPUT = document.getElementById('raritySearchId');
+  var BTN_GO     = document.getElementById('btnGo');
+  var BTN_THEME  = document.getElementById('btnThemeCycle');
   if (!GRID) return;
 
-  // ---------- Config ----------
-  const JSON_RANKS  = CFG.JSON_PATH || 'assets/freshfrogs_rarity_rankings.json'; // [{id, ranking, score}]
-  const LOOKUP_FILE = 'assets/freshfrogs_rank_lookup.json';                      // optional
-  const PAGE_SIZE   = 60;
-  const SIZE        = 128;
+  var PRIMARY_RANK_FILE = CFG.JSON_PATH || 'assets/freshfrogs_rarity_rankings.json';
+  var LOOKUP_FILE       = 'assets/freshfrogs_rank_lookup.json';
+  var STAKED_ONLY       = !!PAGE_CFG.stakedOnly;
+  var DEFAULT_SORT_MODE = (PAGE_CFG.defaultSortMode || 'rank');
+  var SECOND_SORT_MODE  = PAGE_CFG.secondSortMode === false ? null : (PAGE_CFG.secondSortMode || (STAKED_ONLY ? 'time' : 'score'));
+  var SECOND_SORT_LABEL = PAGE_CFG.secondSortLabel || null;
+  var AUTO_MIN_RENDER   = Number(PAGE_CFG.autoLoadMin) || 0;
+  DEFAULT_SORT_MODE = String(DEFAULT_SORT_MODE || 'rank').toLowerCase();
+  if (SECOND_SORT_MODE) SECOND_SORT_MODE = String(SECOND_SORT_MODE).toLowerCase();
+  var PAGE_SIZE         = Number(PAGE_CFG.pageSize || 60);
+  var SOURCE_PATH       = (CFG.SOURCE_PATH || '').replace(/\/+$/, '');
 
-  const RESERVOIR = {
-    HOST: (CFG.RESERVOIR_HOST || 'https://api.reservoir.tools').replace(/\/+$/,''),
-    KEY:  (CFG.FROG_API_KEY || CFG.RESERVOIR_API_KEY || '')
-  };
+  var RESERVOIR_HOST = (CFG.RESERVOIR_HOST || 'https://api.reservoir.tools').replace(/\/+$/, '');
+  var RESERVOIR_KEY  = CFG.FROG_API_KEY || CFG.RESERVOIR_API_KEY || '';
+  var CTRL_ADDR      = (CFG.CONTROLLER_ADDRESS || '').toLowerCase();
+  var CTRL_DEPLOY    = Number(CFG.CONTROLLER_DEPLOY_BLOCK);
 
-  // ---------- CSS (rank pill + green staked like dashboard) ----------
-  (function injectCSS(){
-    if (document.getElementById('rarity-cards-css')) return;
-    const css = `
-.frog-cards{ display:grid; gap:10px; }
-.frog-card{
-  border:1px solid var(--border);
-  background:var(--panel);
-  border-radius:14px;
-  padding:12px;
-  display:grid; grid-template-columns:auto 1fr; column-gap:12px; row-gap:6px; align-items:start;
-  color:inherit;
-}
-.frog-card .thumb-wrap{ width:${SIZE}px; min-width:${SIZE}px; position:relative; }
-.frog-card canvas.frog-canvas{ width:${SIZE}px; height:${SIZE}px; border-radius:12px; background:var(--panel-2); display:block; }
-.frog-card .title{ margin:0; font-weight:900; font-size:18px; letter-spacing:-.01em; display:flex; align-items:center; gap:8px; }
-.frog-card .meta{ color:var(--muted); font-size:12px; }
-.frog-card .attr-bullets{ list-style:disc; margin:6px 0 0 18px; padding:0; color:var(--muted); }
-.frog-card .attr-bullets li{ display:list-item; font-size:12px; margin:2px 0; }
-
-.rank-pill{
-  display:inline-flex; align-items:center; gap:6px;
-  border:1px solid var(--border); border-radius:999px; padding:3px 8px;
-  font-size:11px; font-weight:700; letter-spacing:.01em;
-  background:color-mix(in srgb, var(--panel) 35%, transparent);
-}
-.rank-pill::before{ content:'◆'; font-size:12px; line-height:1; }
-.rank-legendary{ color:#f59e0b; border-color: color-mix(in srgb, #f59e0b 70%, var(--border)); }
-.rank-legendary::before{ color:#f59e0b; }
-.rank-epic{ color:#a855f7; border-color: color-mix(in srgb, #a855f7 70%, var(--border)); }
-.rank-epic::before{ color:#a855f7; }
-.rank-rare{ color:#38bdf8; border-color: color-mix(in srgb, #38bdf8 70%, var(--border)); }
-.rank-rare::before{ color:#38bdf8; }
-.rank-common{ color:inherit; border-color:var(--border); }
-.rank-common::before{ color:var(--muted); }
-
-.meta .staked-flag{ color:#22c55e; font-weight:700; }
-.actions{ grid-column:1 / -1; display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
-.btn{ font-family:var(--font-ui); border:1px solid var(--border); background:transparent; color:inherit; border-radius:8px; padding:6px 10px; font-weight:700; font-size:12px; line-height:1; }
-.btn-outline-gray{ border-color: color-mix(in srgb, #9ca3af 70%, var(--border)); color: color-mix(in srgb, #ffffff 65%, #9ca3af); }
-    `;
-    const s=document.createElement('style'); s.id='rarity-cards-css'; s.textContent=css; document.head.appendChild(s);
-  })();
-
-  // ---------- Utils ----------
-  const asNum = (x)=> { const n = Number(x); return Number.isFinite(n)?n:NaN; };
-  const getRankLike = (o)=> asNum(o.rank ?? o.ranking ?? o.position ?? o.place);
-  const shortAddr = (a)=> a && typeof a==='string' ? (a.length>10 ? (a.slice(0,6)+'…'+a.slice(-4)) : a) : '—';
-  const traitKey  = (t)=> (t?.key ?? t?.trait_type ?? t?.traitType ?? t?.trait ?? '').toString().trim();
-  const traitVal  = (t)=> (t?.value ?? t?.trait_value ?? '').toString().trim();
-
-  // Same thresholds as dashboard (owned-panel.js)
-  function rankTier(rank){
-    const r = Number(rank);
-    if (!Number.isFinite(r)) return 'common';
-    const T = (CFG.RARITY_TIERS) || { legendary: 50, epic: 250, rare: 800 };
-    if (r <= T.legendary) return 'legendary';
-    if (r <= T.epic)      return 'epic';
-    if (r <= T.rare)      return 'rare';
-    return 'common';
+  var allItems   = [];
+  var viewItems  = [];
+  var offset     = 0;
+  var sortMode   = DEFAULT_SORT_MODE;
+  if (sortMode !== 'rank' && sortMode !== 'score' && sortMode !== 'time') {
+    sortMode = 'rank';
   }
-  function rankPill(rank){
-    const tier = rankTier(rank);
-    const span = document.createElement('span');
-    span.className = `rank-pill rank-${tier}`;
-    span.textContent = `#${rank}`;
-    return span;
-  }
-  function fmtAgo(ms){
-    if(!ms||!isFinite(ms))return null;
-    const s=Math.max(0,Math.floor((Date.now()-ms)/1000));
-    const d=Math.floor(s/86400); if(d>=1) return d+'d ago';
-    const h=Math.floor((s%86400)/3600);  if(h>=1) return h+'h ago';
-    const m=Math.floor((s%3600)/60);     if(m>=1) return m+'m ago';
-    return s+'s ago';
+  var renderCount = 0;
+  var lookupMap  = null; // Map<id, {rank, score}>
+  var currentUser = null;
+  var STORAGE_KEY_THEME = 'ff_rarity_theme';
+  var THEMES = [
+    { id: 'atlas',     label: 'Atlas Mint' },
+    { id: 'moonglow',  label: 'Moonglow Neon' },
+    { id: 'sunset',    label: 'Sunset Mirage' },
+    { id: 'evergreen', label: 'Evergreen Trail' },
+    { id: 'lilypad',   label: 'Lilypad Bloom' },
+    { id: 'abyss',     label: 'Abyssal Tide' },
+    { id: 'horizon',   label: 'High Horizon' },
+    { id: 'embercore', label: 'Ember Core' },
+    { id: 'frostbite', label: 'Frostbite Veil' },
+    { id: 'citrine',   label: 'Citrine Flash' }
+  ];
+  var themeIndex = 0;
+
+  function uiError(msg) {
+    GRID.innerHTML = '<div class="pg-muted" style="padding:10px">' + msg + '</div>';
+    renderCount = 0;
   }
 
-  // owner logic
-  async function getUserAddress(){
-    try{ if (window.FF_WALLET?.address) return window.FF_WALLET.address; }catch{}
-    try{ if (window.ethereum?.request){ const a=await window.ethereum.request({method:'eth_accounts'}); return a?.[0]||null; } }catch{}
+  function clearGrid() {
+    GRID.innerHTML = '';
+    renderCount = 0;
+    if (GRID.classList && GRID.classList.add) {
+      GRID.classList.add('frog-cards');
+    }
+  }
+
+  function ensureMoreBtn() {
+    if (!BTN_MORE) return;
+    BTN_MORE.style.display = offset < viewItems.length ? 'inline-flex' : 'none';
+  }
+
+  function asNum(x) {
+    var n = Number(x);
+    return isFinite(n) ? n : NaN;
+  }
+
+  function labelForSort(mode) {
+    if (mode === 'rank') return 'Sort: Rank ↑';
+    if (mode === 'score') return 'Sort: Score ↓';
+    if (mode === 'time' || mode === 'stakedTime') return 'Sort: Time ↑';
+    return 'Sort';
+  }
+
+  function getRankLike(obj) {
+    if (!obj) return NaN;
+    if (obj.rank != null) return asNum(obj.rank);
+    if (obj.ranking != null) return asNum(obj.ranking);
+    if (obj.position != null) return asNum(obj.position);
+    if (obj.place != null) return asNum(obj.place);
+    return NaN;
+  }
+
+  function shortAddr(addr) {
+    if (!addr || typeof addr !== 'string') return '\u2014';
+    if (addr.length <= 10) return addr;
+    return addr.slice(0, 6) + '\u2026' + addr.slice(-4);
+  }
+
+  function traitKey(t) {
+    if (!t) return '';
+    var keys = ['key', 'trait_type', 'traitType', 'trait'];
+    for (var i = 0; i < keys.length; i++) {
+      if (t[keys[i]] != null) {
+        return String(t[keys[i]]).trim();
+      }
+    }
+    return '';
+  }
+
+  function traitVal(t) {
+    if (!t) return '';
+    var keys = ['value', 'trait_value'];
+    for (var i = 0; i < keys.length; i++) {
+      if (t[keys[i]] != null) {
+        return String(t[keys[i]]).trim();
+      }
+    }
+    return '';
+  }
+
+  function fmtAgo(ms) {
+    if (!ms || !isFinite(ms)) return null;
+    var s = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+    var d = Math.floor(s / 86400);
+    if (d >= 1) return d + 'd ago';
+    var h = Math.floor((s % 86400) / 3600);
+    if (h >= 1) return h + 'h ago';
+    var m = Math.floor((s % 3600) / 60);
+    if (m >= 1) return m + 'm ago';
+    return s + 's ago';
+  }
+
+  function sinceMs(sec) {
+    if (sec == null) return null;
+    var n = Number(sec);
+    if (!isFinite(n)) return null;
+    return n > 1e12 ? n : n * 1000;
+  }
+
+  function readStoredTheme() {
+    try {
+      if (global.localStorage) {
+        return global.localStorage.getItem(STORAGE_KEY_THEME);
+      }
+    } catch (err) {}
     return null;
   }
 
-  // On-chain owner (fallback to Reservoir)
-  let _web3,_col;
-  function getWeb3(){ if (_web3) return _web3; _web3 = new Web3(window.ethereum || Web3.givenProvider || ""); return _web3; }
-  function getCollectionContract(){
-    if (_col) return _col;
-    if (!CFG.COLLECTION_ADDRESS || !window.COLLECTION_ABI) return null;
-    _col = new (getWeb3()).eth.Contract(window.COLLECTION_ABI, CFG.COLLECTION_ADDRESS);
-    return _col;
-  }
-  async function ownerFromContract(id){
-    try{ const c=getCollectionContract(); if (!c) return null; return await c.methods.ownerOf(String(id)).call(); }
-    catch{ return null; }
-  }
-  async function ownerFromReservoir(id){
-    if (!RESERVOIR.KEY || !CFG.COLLECTION_ADDRESS) return null;
-    const url = `${RESERVOIR.HOST}/owners/v2?tokens=${encodeURIComponent(`${CFG.COLLECTION_ADDRESS}:${id}`)}&limit=1`;
-    try{
-      const r = await fetch(url, { headers: { accept:'application/json', 'x-api-key': RESERVOIR.KEY } });
-      if (!r.ok) return null;
-      const j = await r.json();
-      const own = j?.owners?.[0]?.owner;
-      return (typeof own==='string' && own.startsWith('0x')) ? own : null;
-    }catch{ return null; }
-  }
-  async function fetchOwnerOf(id){
-    const onchain = await ownerFromContract(id);
-    if (onchain) return onchain;
-    const api = await ownerFromReservoir(id);
-    return api || null;
-  }
-
-  // staking info (reuses any adapter if present)
-  async function fetchStakeInfo(id){
+  function storeTheme(id) {
     try {
-      if (FF.staking?.getStakeInfo) return await FF.staking.getStakeInfo(id);
-      if (window.STAKING_ADAPTER?.getStakeInfo) return await window.STAKING_ADAPTER.getStakeInfo(id);
-    } catch {}
-    return { staked:false, since:null };
+      if (global.localStorage) {
+        global.localStorage.setItem(STORAGE_KEY_THEME, id);
+      }
+    } catch (err) {}
   }
-  const sinceMs = (sec)=> {
-    if (sec==null) return null;
-    const n = Number(sec); if (!Number.isFinite(n)) return null;
-    return n > 1e12 ? n : n*1000;
-  };
 
-  // metadata
-  async function fetchMeta(id){
-    const tries = [
-      `frog/json/${id}.json`,
-      `frog/${id}.json`,
-      `assets/frogs/${id}.json`
-    ];
-    for (const u of tries){
-      try{ const r=await fetch(u,{cache:'no-store'}); if (r.ok) return await r.json(); }catch{}
+  function applyTheme(idx) {
+    if (!THEMES.length) return;
+    if (idx < 0) idx = 0;
+    if (idx >= THEMES.length) idx = 0;
+    themeIndex = idx;
+    var theme = THEMES[idx];
+    try {
+      if (document && document.documentElement) {
+        document.documentElement.setAttribute('data-theme', theme.id);
+      }
+    } catch (err1) {}
+    if (BTN_THEME) {
+      BTN_THEME.textContent = 'Theme: ' + theme.label + ' (' + (idx + 1) + '/' + THEMES.length + ')';
     }
-    return { name:`Frog #${id}`, attributes:[] };
+    storeTheme(theme.id);
   }
 
-  // ---------- Rankings ----------
-  async function fetchJSON(url){ const r=await fetch(url,{cache:'no-store'}); if(!r.ok) throw new Error(r.status); return r.json(); }
-  function normalizeRankingsArray(arr){
-    return arr.map(x => ({
-      id:   asNum(x.id ?? x.tokenId ?? x.token_id ?? x.frogId ?? x.frog_id),
-      rank: getRankLike(x),
-      score: asNum(x.score ?? x.rarityScore ?? x.points ?? 0)
-    }))
-    .filter(r => Number.isFinite(r.id) && Number.isFinite(r.rank) && r.rank>0)
-    .sort((a,b)=>a.rank-b.rank);
+  function applyThemeById(id) {
+    if (!id) {
+      applyTheme(0);
+      return;
+    }
+    for (var i = 0; i < THEMES.length; i++) {
+      if (THEMES[i].id === id) {
+        applyTheme(i);
+        return;
+      }
+    }
+    applyTheme(0);
   }
-  async function loadRankings(){
-    const primary = await fetchJSON(JSON_RANKS).catch(()=>[]);
-    let rows = Array.isArray(primary) ? normalizeRankingsArray(primary) : [];
-    if (!rows.length){
-      // optional lookup fallback
-      try{
-        const j = await fetchJSON(LOOKUP_FILE);
-        if (j && typeof j === 'object'){
-          rows = Object.entries(j).map(([rk,id])=>({ id: asNum(id), rank: asNum(rk), score: 0 }))
-                  .filter(r=>Number.isFinite(r.id)&&Number.isFinite(r.rank))
-                  .sort((a,b)=>a.rank-b.rank);
+
+  function initThemeCycle() {
+    if (!THEMES.length) return;
+    var startId = null;
+    try {
+      if (document && document.documentElement) {
+        startId = document.documentElement.getAttribute('data-theme');
+      }
+    } catch (err) {}
+    if (!startId) {
+      startId = readStoredTheme();
+    }
+    if (!startId) {
+      startId = THEMES[0].id;
+    }
+    applyThemeById(startId);
+    if (BTN_THEME) {
+      BTN_THEME.addEventListener('click', function(){
+        applyTheme((themeIndex + 1) % THEMES.length);
+      });
+    }
+  }
+
+  function getUserAddress() {
+    return new Promise(function(resolve){
+      try {
+        if (global.FF_WALLET && global.FF_WALLET.address) {
+          resolve(global.FF_WALLET.address);
+          return;
         }
-      }catch{}
-    }
-    return rows;
+      } catch (err) {}
+
+      try {
+        if (global.ethereum && typeof global.ethereum.request === 'function') {
+          global.ethereum.request({ method: 'eth_accounts' }).then(function(arr){
+            resolve(arr && arr.length ? arr[0] : null);
+          }).catch(function(){ resolve(null); });
+          return;
+        }
+      } catch (err2) {}
+
+      resolve(null);
+    });
   }
 
-  // ---------- Card ----------
-  function buildCard(rec, userAddr){
-    const { id, rank, meta, owner, stake } = rec;
-
-    const card = document.createElement('article');
-    card.className = 'frog-card';
-    card.setAttribute('data-token-id', String(id));
-
-    // media: host a hidden canvas; FF.renderFrog will stack DOM layers in the same order as metadata
-    const media = document.createElement('div');
-    media.className = 'thumb-wrap';
-    const cv = document.createElement('canvas');
-    cv.className = 'frog-canvas'; cv.width = SIZE; cv.height = SIZE;
-    media.appendChild(cv);
-
-    // title: Frog #id + rank pill (dashboard style)
-    const title = document.createElement('h4');
-    title.className = 'title';
-    title.textContent = meta?.name || `Frog #${id}`;
-    const pill = rankPill(rank);
-    title.appendChild(pill);
-
-    // subtitle: staked line + owner
-    const metaLine = document.createElement('div');
-    metaLine.className = 'meta';
-    const me = userAddr && owner && userAddr.toLowerCase() === owner.toLowerCase();
-
-    const stakeSpan = document.createElement('span');
-    if (stake?.staked) {
-      const ago = sinceMs(stake?.since) ? fmtAgo(sinceMs(stake?.since)) : null;
-      stakeSpan.className = 'staked-flag';
-      stakeSpan.textContent = ago ? `Staked ${ago}` : 'Staked';
-    } else {
-      stakeSpan.textContent = 'Not staked';
-    }
-    const sep = document.createElement('span'); sep.textContent = ' • ';
-    const ownerSpan = document.createElement('span');
-    ownerSpan.textContent = `Owned by ${me ? 'You' : shortAddr(owner)}`;
-
-    metaLine.appendChild(stakeSpan);
-    metaLine.appendChild(sep);
-    metaLine.appendChild(ownerSpan);
-
-    // attributes (vertical)
-    const list = document.createElement('ul');
-    list.className = 'attr-bullets';
-    (Array.isArray(meta?.attributes)? meta.attributes: []).forEach(a=>{
-      const k=traitKey(a), v=traitVal(a); if(!k||!v) return;
-      const li=document.createElement('li'); li.innerHTML = `<b>${k}:</b> ${v}`; list.appendChild(li);
+  function fetchJson(url) {
+    return fetch(url, { cache: 'no-store' }).then(function(res){
+      if (!res.ok) throw new Error('HTTP ' + res.status + ' fetching ' + url);
+      return res.json();
     });
+  }
 
-    // actions (view-only)
-    const actions = document.createElement('div'); actions.className='actions';
-    const aOS  = document.createElement('a'); aOS.className='btn btn-outline-gray'; aOS.textContent='OpenSea';
-    aOS.href = `https://opensea.io/assets/ethereum/${CFG.COLLECTION_ADDRESS}/${id}`; aOS.target='_blank'; aOS.rel='noopener';
-    const aScan= document.createElement('a'); aScan.className='btn btn-outline-gray'; aScan.textContent='Etherscan';
-    aScan.href = `https://etherscan.io/token/${CFG.COLLECTION_ADDRESS}?a=${id}`; aScan.target='_blank'; aScan.rel='noopener';
-    const aOrig= document.createElement('a'); aOrig.className='btn btn-outline-gray'; aOrig.textContent='Original';
-    aOrig.href = `frog/${id}.png`; aOrig.target='_blank'; aOrig.rel='noopener';
-    actions.appendChild(aOS); actions.appendChild(aScan); actions.appendChild(aOrig);
+  function parseRankToIdMap(obj) {
+    var map = new Map();
+    for (var key in obj) {
+      if (!obj.hasOwnProperty(key)) continue;
+      var rank = asNum(key);
+      var id = asNum(obj[key]);
+      if (isFinite(rank) && isFinite(id)) {
+        map.set(id, { rank: rank, score: 0 });
+      }
+    }
+    return map.size ? map : null;
+  }
 
-    // compose
-    card.appendChild(media);
-    const right = document.createElement('div');
+  function normalizeRankingsArray(arr) {
+    return arr
+      .map(function(x){
+        var id = asNum(x && (x.id != null ? x.id : (x.tokenId != null ? x.tokenId : (x.token_id != null ? x.token_id : (x.frogId != null ? x.frogId : x.frog_id)))));
+        var rank = getRankLike(x);
+        var score = asNum(x && (x.score != null ? x.score : (x.rarityScore != null ? x.rarityScore : x.points)));
+        if (!isFinite(score)) score = 0;
+        return { id: id, rank: rank, score: score };
+      })
+      .filter(function(r){ return isFinite(r.id) && isFinite(r.rank) && r.rank > 0; })
+      .sort(function(a, b){ return a.rank - b.rank; });
+  }
+
+  function loadLookup() {
+    return fetchJson(LOOKUP_FILE).then(function(json){
+      if (Array.isArray(json)) {
+        var map = new Map();
+        for (var i = 0; i < json.length; i++) {
+          var id = asNum(json[i]);
+          if (isFinite(id)) map.set(id, { rank: i + 1, score: 0 });
+        }
+        lookupMap = map.size ? map : null;
+      } else if (json && typeof json === 'object') {
+        lookupMap = parseRankToIdMap(json);
+      } else {
+        lookupMap = null;
+      }
+    }).catch(function(err){
+      console.warn('[rarity] lookup load failed', err);
+      lookupMap = null;
+    });
+  }
+
+  function loadPrimaryRanks() {
+    return fetchJson(PRIMARY_RANK_FILE).then(function(json){
+      if (!Array.isArray(json)) return [];
+      var arr = normalizeRankingsArray(json);
+      if (lookupMap) {
+        arr.forEach(function(r){
+          var lk = lookupMap.get(r.id);
+          if (!lk) return;
+          if (!isFinite(r.rank) && isFinite(lk.rank)) r.rank = lk.rank;
+          if (!isFinite(r.score) && isFinite(lk.score)) r.score = lk.score;
+        });
+        arr.sort(function(a, b){ return a.rank - b.rank; });
+      }
+      return arr;
+    }).catch(function(err){
+      console.warn('[rarity] primary rankings load failed', err);
+      return [];
+    });
+  }
+
+  function fetchMeta(id) {
+    var tries = [
+      'frog/json/' + id + '.json',
+      'frog/' + id + '.json',
+      'assets/frogs/' + id + '.json'
+    ];
+
+    var next = function(ix){
+      if (ix >= tries.length) {
+        return Promise.resolve({ name: 'Frog #' + id, image: 'frog/' + id + '.png', attributes: [] });
+      }
+      var url = tries[ix];
+      return fetch(url, { cache: 'no-store' }).then(function(res){
+        if (!res.ok) return next(ix + 1);
+        return res.json();
+      }).catch(function(){
+        return next(ix + 1);
+      });
+    };
+
+    return next(0);
+  }
+
+  function normalizeAttrs(meta) {
+    var out = [];
+    var arr = meta && Array.isArray(meta.attributes) ? meta.attributes : [];
+    for (var i = 0; i < arr.length; i++) {
+      var key = traitKey(arr[i]);
+      var val = traitVal(arr[i]);
+      if (!key || !val) continue;
+      out.push({ key: key, value: val });
+    }
+    return out;
+  }
+
+  var _web3 = null;
+  var _collection = null;
+  var _controller = null;
+  var _stakeSinceCache = new Map();
+  var _stakerCache = new Map();
+
+  function getWeb3(){
+    if (_web3) return _web3;
+    if (!global.Web3) return null;
+
+    var provider = null;
+    if (global.ethereum) {
+      provider = global.ethereum;
+    } else if (global.Web3.givenProvider) {
+      provider = global.Web3.givenProvider;
+    } else if (CFG.RPC_URL && global.Web3 && global.Web3.providers && global.Web3.providers.HttpProvider) {
+      try {
+        provider = new global.Web3.providers.HttpProvider(CFG.RPC_URL);
+      } catch (err) {
+        console.warn('[rarity] failed to build HttpProvider', err);
+      }
+    }
+
+    if (!provider) return null;
+
+    _web3 = new global.Web3(provider);
+    return _web3;
+  }
+
+  function resolveCollectionAbi(){
+    if (typeof global.COLLECTION_ABI !== 'undefined') return global.COLLECTION_ABI;
+    if (typeof global.collection_abi !== 'undefined') return global.collection_abi;
+    if (typeof COLLECTION_ABI !== 'undefined') return COLLECTION_ABI;
+    if (typeof collection_abi !== 'undefined') return collection_abi;
+    return null;
+  }
+
+  function resolveControllerAbi(){
+    if (typeof global.CONTROLLER_ABI !== 'undefined') return global.CONTROLLER_ABI;
+    if (typeof global.controller_abi !== 'undefined') return global.controller_abi;
+    if (typeof CONTROLLER_ABI !== 'undefined') return CONTROLLER_ABI;
+    if (typeof controller_abi !== 'undefined') return controller_abi;
+    return null;
+  }
+
+  function getCollectionContract(){
+    if (_collection) return _collection;
+    if (!CFG.COLLECTION_ADDRESS) return null;
+    var abi = resolveCollectionAbi();
+    if (!abi || !abi.length) return null;
+    var web3 = getWeb3();
+    if (!web3 || !web3.eth || !web3.eth.Contract) return null;
+    _collection = new web3.eth.Contract(abi, CFG.COLLECTION_ADDRESS);
+    return _collection;
+  }
+
+  function getControllerContract(){
+    if (_controller) return _controller;
+    if (!CFG.CONTROLLER_ADDRESS) return null;
+    var abi = resolveControllerAbi();
+    if (!abi || !abi.length) return null;
+    var web3 = getWeb3();
+    if (!web3 || !web3.eth || !web3.eth.Contract) return null;
+    _controller = new web3.eth.Contract(abi, CFG.CONTROLLER_ADDRESS);
+    return _controller;
+  }
+
+  function isHexAddress(addr){
+    return typeof addr === 'string' && addr.indexOf('0x') === 0 && addr.length === 42;
+  }
+
+  function padTokenHex(id){
+    var n = Number(id);
+    if (!isFinite(n) || n < 0) n = 0;
+    var hex = n.toString(16);
+    while (hex.length < 64) hex = '0' + hex;
+    return '0x' + hex;
+  }
+
+  function fetchStakeTimestamp(id){
+    if (_stakeSinceCache.has(id)) return Promise.resolve(_stakeSinceCache.get(id));
+
+    return new Promise(function(resolve){
+      try {
+        var web3 = getWeb3();
+        if (!web3 || !web3.eth || !web3.eth.getPastLogs || !CFG.COLLECTION_ADDRESS || !CTRL_ADDR) {
+          _stakeSinceCache.set(id, null);
+          resolve(null);
+          return;
+        }
+
+        var topics = [
+          '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+          null,
+          '0x000000000000000000000000' + CTRL_ADDR.slice(2),
+          padTokenHex(id)
+        ];
+
+        var fromBlock = isFinite(CTRL_DEPLOY) && CTRL_DEPLOY > 0 ? '0x' + CTRL_DEPLOY.toString(16) : '0x0';
+
+        web3.eth.getPastLogs({
+          fromBlock: fromBlock,
+          toBlock: 'latest',
+          address: CFG.COLLECTION_ADDRESS,
+          topics: topics
+        }).then(function(logs){
+          if (!logs || !logs.length) {
+            _stakeSinceCache.set(id, null);
+            resolve(null);
+            return;
+          }
+          var last = logs[logs.length - 1];
+          web3.eth.getBlock(last.blockNumber).then(function(block){
+            var ts = block && block.timestamp != null ? Number(block.timestamp) : null;
+            var ms = ts ? (ts > 1e12 ? ts : ts * 1000) : null;
+            _stakeSinceCache.set(id, ms);
+            resolve(ms);
+          }).catch(function(err){
+            console.warn('[rarity] stake block lookup failed', err);
+            _stakeSinceCache.set(id, null);
+            resolve(null);
+          });
+        }).catch(function(err2){
+          console.warn('[rarity] stake log lookup failed', err2);
+          _stakeSinceCache.set(id, null);
+          resolve(null);
+        });
+      } catch (err3) {
+        console.warn('[rarity] stake timestamp error', err3);
+        _stakeSinceCache.set(id, null);
+        resolve(null);
+      }
+    });
+  }
+
+  function fetchStakerAddress(id){
+    if (_stakerCache.has(id)) return Promise.resolve(_stakerCache.get(id));
+
+    return new Promise(function(resolve){
+      try {
+        var ctrl = getControllerContract();
+        if (!ctrl || !ctrl.methods || !ctrl.methods.stakerAddress) {
+          _stakerCache.set(id, null);
+          resolve(null);
+          return;
+        }
+        ctrl.methods.stakerAddress(String(id)).call().then(function(addr){
+          if (!addr || !isHexAddress(addr) || addr === '0x0000000000000000000000000000000000000000') {
+            _stakerCache.set(id, null);
+            resolve(null);
+            return;
+          }
+          _stakerCache.set(id, addr);
+          resolve(addr);
+        }).catch(function(err){
+          console.warn('[rarity] staker lookup failed', err);
+          _stakerCache.set(id, null);
+          resolve(null);
+        });
+      } catch (err2) {
+        console.warn('[rarity] staker error', err2);
+        _stakerCache.set(id, null);
+        resolve(null);
+      }
+    });
+  }
+
+  function ownerFromContract(id){
+    return new Promise(function(resolve){
+      try {
+        var contract = getCollectionContract();
+        if (!contract) { resolve(null); return; }
+        contract.methods.ownerOf(String(id)).call().then(function(addr){
+          resolve(addr || null);
+        }).catch(function(){ resolve(null); });
+      } catch (err) {
+        resolve(null);
+      }
+    });
+  }
+
+  function ownerFromReservoir(id){
+    if (!RESERVOIR_KEY || !CFG.COLLECTION_ADDRESS) return Promise.resolve(null);
+    var token = CFG.COLLECTION_ADDRESS + ':' + id;
+    var url = RESERVOIR_HOST + '/owners/v2?tokens=' + encodeURIComponent(token) + '&limit=1';
+    return fetch(url, {
+      headers: {
+        accept: 'application/json',
+        'x-api-key': RESERVOIR_KEY
+      }
+    }).then(function(res){
+      if (!res.ok) return null;
+      return res.json();
+    }).then(function(json){
+      if (!json || !json.owners || !json.owners.length) return null;
+      var owner = json.owners[0] && json.owners[0].owner;
+      return (typeof owner === 'string' && owner.indexOf('0x') === 0) ? owner : null;
+    }).catch(function(err){
+      console.warn('[rarity] reservoir owner lookup failed', err);
+      return null;
+    });
+  }
+
+  function fetchOwnerOf(id){
+    return ownerFromContract(id).then(function(onchain){
+      var holder = isHexAddress(onchain) ? onchain : null;
+      var controllerOwned = !!(holder && CTRL_ADDR && holder.toLowerCase() === CTRL_ADDR);
+
+      if (controllerOwned) {
+        return fetchStakerAddress(id).then(function(staker){
+          return (staker ? Promise.resolve(staker) : ownerFromReservoir(id)).then(function(ownerGuess){
+            return fetchStakeTimestamp(id).then(function(since){
+              return {
+                owner: staker || ownerGuess || null,
+                holder: holder,
+                controllerOwned: true,
+                stakeSinceMs: since,
+                staker: staker || null
+              };
+            });
+          });
+        });
+      }
+
+      if (holder) {
+        return {
+          owner: holder,
+          holder: holder,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      }
+
+      return ownerFromReservoir(id).then(function(resOwner){
+        return {
+          owner: resOwner || null,
+          holder: holder,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      });
+    }).catch(function(err){
+      console.warn('[rarity] owner lookup fallback', err);
+      return ownerFromReservoir(id).then(function(resOwner){
+        return {
+          owner: resOwner || null,
+          holder: null,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      }).catch(function(){
+        return {
+          owner: null,
+          holder: null,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      });
+    });
+  }
+
+  function fetchStakeInfo(id){
+    return new Promise(function(resolve){
+      var done = false;
+      function finish(info){
+        if (done) return;
+        done = true;
+        resolve(info || { staked: false, since: null });
+      }
+
+      try {
+        if (FF.staking && typeof FF.staking.getStakeInfo === 'function') {
+          FF.staking.getStakeInfo(id).then(function(info){ finish(info); }).catch(function(){ finish(null); });
+          return;
+        }
+      } catch (err) {
+        console.warn('[rarity] staking info via FF.staking failed', err);
+      }
+
+      try {
+        if (global.STAKING_ADAPTER && typeof global.STAKING_ADAPTER.getStakeInfo === 'function') {
+          global.STAKING_ADAPTER.getStakeInfo(id).then(function(info){ finish(info); }).catch(function(){ finish(null); });
+          return;
+        }
+      } catch (err2) {
+        console.warn('[rarity] staking adapter lookup failed', err2);
+      }
+
+      finish(null);
+    });
+  }
+
+  function normalizeStake(info){
+    var staked = info && !!info.staked;
+    var since = null;
+    if (info) {
+      if (info.since != null) since = info.since;
+      else if (info.sinceMs != null) since = info.sinceMs;
+      else if (info.since_ms != null) since = info.since_ms;
+      else if (info.stakedSince != null) since = info.stakedSince;
+    }
+    return { staked: staked, sinceMs: sinceMs(since) };
+  }
+
+  function fallbackMetaLine(item){
+    var ownerLabel = null;
+    if (item.ownerYou) ownerLabel = 'You';
+    else if (item.ownerShort && item.ownerShort !== '\u2014') ownerLabel = item.ownerShort;
+    else if (item.owner) ownerLabel = shortAddr(item.owner);
+    else if (item.holder) ownerLabel = shortAddr(item.holder);
+    if (!ownerLabel) ownerLabel = 'Unknown';
+    if (item.staked) {
+      var ago = item.sinceMs ? fmtAgo(item.sinceMs) : null;
+      var agoHtml = ago ? ('<span class="ago-line">' + ago + '</span>') : '';
+      return '<span class="staked-flag">Staked</span> by ' + ownerLabel + agoHtml;
+    }
+    return 'Owned by ' + ownerLabel;
+  }
+
+  function metaLineForCard(item){
+    try {
+      if (global.FF && typeof global.FF.formatOwnerLine === 'function') {
+        return global.FF.formatOwnerLine(item);
+      }
+    } catch (err) {
+      console.warn('[rarity] meta line formatter failed', err);
+    }
+    return fallbackMetaLine(item);
+  }
+
+  function buildFallbackCard(rec) {
+    var card = document.createElement('article');
+    card.className = 'frog-card';
+    card.setAttribute('data-token-id', String(rec.id));
+
+    var row = document.createElement('div');
+    row.className = 'row';
+
+    var thumbWrap = document.createElement('div');
+    thumbWrap.className = 'thumb-wrap';
+
+    var img = document.createElement('img');
+    img.className = 'thumb';
+    img.alt = (rec.metaRaw && rec.metaRaw.name) ? rec.metaRaw.name : ('Frog #' + rec.id);
+    img.loading = 'lazy';
+    img.src = (rec.metaRaw && rec.metaRaw.image) ? rec.metaRaw.image : (SOURCE_PATH + '/frog/' + rec.id + '.png');
+    thumbWrap.appendChild(img);
+
+    var right = document.createElement('div');
+    var title = document.createElement('h4');
+    title.className = 'title';
+    title.textContent = (rec.metaRaw && rec.metaRaw.name) ? rec.metaRaw.name : ('Frog #' + rec.id);
+    if (rec.rank != null) {
+      var pill = document.createElement('span');
+      pill.className = 'pill';
+      pill.textContent = '♦ #' + rec.rank;
+      title.appendChild(pill);
+    }
+    var metaLine = document.createElement('div');
+    metaLine.className = 'meta';
+    metaLine.innerHTML = metaLineForCard(rec);
+
     right.appendChild(title);
     right.appendChild(metaLine);
-    if (list.childNodes.length) right.appendChild(list);
-    right.appendChild(actions);
-    card.appendChild(right);
 
-    // render layered frog (metadata order) at 128×128
-    (async ()=>{
-      try{
-        await (FF.renderFrog ? FF.renderFrog(cv, rec.metaRaw || meta, { size: SIZE, tokenId: id }) : Promise.reject());
-      }catch{
-        // fallback to still image if renderer not available
-        const img = document.createElement('img'); img.src = `frog/${id}.png`; img.alt = String(id); img.className = 'frog-canvas';
-        media.innerHTML=''; media.appendChild(img);
-      }
-    })();
+    if (rec.attrs && rec.attrs.length) {
+      var list = document.createElement('ul');
+      list.className = 'attr-bullets';
+      rec.attrs.forEach(function(attr){
+        var li = document.createElement('li');
+        li.innerHTML = '<b>' + attr.key + ':</b> ' + attr.value;
+        list.appendChild(li);
+      });
+      right.appendChild(list);
+    }
 
+    row.appendChild(thumbWrap);
+    row.appendChild(right);
+    card.appendChild(row);
     return card;
   }
 
-  // ---------- Paging / render ----------
-  let rows=[], view=[], offset=0, sortMode='rank';
-  function ensureMoreBtn(){ if (BTN_MORE) BTN_MORE.style.display = offset < view.length ? 'inline-flex' : 'none'; }
-  function clearGrid(){ GRID.innerHTML=''; GRID.classList.add('frog-cards'); }
+  function buildCard(rec) {
+    if (global.FF && typeof global.FF.buildFrogCard === 'function') {
+      return global.FF.buildFrogCard({
+        id: rec.id,
+        rank: rec.rank,
+        attrs: rec.attrs,
+        staked: rec.staked,
+        sinceMs: rec.sinceMs,
+        metaRaw: rec.metaRaw,
+        owner: rec.owner,
+        ownerShort: rec.ownerShort,
+        ownerYou: rec.ownerYou,
+        holder: rec.holder
+      }, {
+        showActions: false,
+        rarityTiers: CFG.RARITY_TIERS,
+        metaLine: metaLineForCard
+      });
+    }
+    return buildFallbackCard(rec);
+  }
 
-  async function loadMore(userAddr){
-    const slice = view.slice(offset, offset + PAGE_SIZE);
-    if (!slice.length) { ensureMoreBtn(); return; }
-
-    const metas  = await Promise.all(slice.map(x => fetchMeta(x.id)));
-    const owners = await Promise.all(slice.map(x => fetchOwnerOf(x.id)));
-    const stakes = await Promise.all(slice.map(x => fetchStakeInfo(x.id)));
-
-    for (let i=0;i<slice.length;i++){
-      slice[i].meta = metas[i];
-      slice[i].metaRaw = metas[i]; // pass through for renderer
-      slice[i].owner = owners[i] || null;
-      slice[i].stake = stakes[i] || {staked:false, since:null};
+  function loadMore() {
+    var slice = viewItems.slice(offset, offset + PAGE_SIZE);
+    if (!slice.length) {
+      ensureMoreBtn();
+      return Promise.resolve();
     }
 
-    const frag=document.createDocumentFragment();
-    slice.forEach(rec => frag.appendChild(buildCard(rec, userAddr)));
-    GRID.appendChild(frag);
+    return Promise.all(slice.map(function(x){ return fetchMeta(x.id); }))
+      .then(function(metas){
+        return Promise.all(slice.map(function(x){ return fetchOwnerOf(x.id); })).then(function(owners){
+          return Promise.all(slice.map(function(x){ return fetchStakeInfo(x.id); })).then(function(stakes){
+            var frag = document.createDocumentFragment();
+            var appended = 0;
+            for (var i = 0; i < slice.length; i++) {
+              var meta = metas[i] || { attributes: [] };
+              var ownerInfo = owners[i] || {};
+              if (ownerInfo && typeof ownerInfo === 'string') {
+                ownerInfo = { owner: ownerInfo, holder: ownerInfo, controllerOwned: false, stakeSinceMs: null, staker: null };
+              }
+              var stake = normalizeStake(stakes[i] || null);
+              var attrs = normalizeAttrs(meta);
 
-    offset += slice.length;
-    ensureMoreBtn();
+              var isStaked = stake.staked || !!ownerInfo.controllerOwned;
+              var since = stake.sinceMs || ownerInfo.stakeSinceMs || null;
+              var actualOwner = ownerInfo.owner || null;
+              if (!actualOwner && !isStaked && ownerInfo.holder) {
+                actualOwner = ownerInfo.holder;
+              }
+              if (!actualOwner && ownerInfo.staker) {
+                actualOwner = ownerInfo.staker;
+              }
+
+              var ownerShort = actualOwner ? shortAddr(actualOwner) : null;
+              var ownerYou = false;
+              if (currentUser && actualOwner && typeof currentUser === 'string' && typeof actualOwner === 'string') {
+                ownerYou = currentUser.toLowerCase() === actualOwner.toLowerCase();
+              } else if (currentUser && !actualOwner && ownerInfo.holder && typeof ownerInfo.holder === 'string') {
+                ownerYou = currentUser.toLowerCase() === ownerInfo.holder.toLowerCase();
+              }
+
+              slice[i].staked = isStaked;
+              slice[i].sinceMs = since;
+              slice[i].owner = actualOwner;
+              slice[i].ownerShort = ownerShort;
+              slice[i].ownerYou = ownerYou;
+              slice[i].holder = ownerInfo && ownerInfo.holder ? ownerInfo.holder : null;
+              slice[i].metaRaw = meta;
+              slice[i].attrs = attrs;
+
+              if (STAKED_ONLY && !isStaked) {
+                continue;
+              }
+
+              var rec = {
+                id: slice[i].id,
+                rank: slice[i].rank,
+                score: slice[i].score,
+                metaRaw: meta,
+                attrs: attrs,
+                staked: isStaked,
+                sinceMs: since,
+                owner: actualOwner,
+                ownerShort: ownerShort,
+                ownerYou: ownerYou,
+                holder: ownerInfo && ownerInfo.holder ? ownerInfo.holder : null
+              };
+              frag.appendChild(buildCard(rec));
+              appended += 1;
+            }
+
+            if (appended) {
+              GRID.appendChild(frag);
+              renderCount += appended;
+            }
+            offset += slice.length;
+            ensureMoreBtn();
+            if (STAKED_ONLY) {
+              if (!appended && offset < viewItems.length) {
+                return loadMore();
+              }
+              if (!appended && offset >= viewItems.length && renderCount === 0) {
+                uiError('No staked frogs found.');
+                if (BTN_MORE) BTN_MORE.style.display = 'none';
+                return;
+              }
+              if (AUTO_MIN_RENDER > 0 && renderCount < AUTO_MIN_RENDER && offset < viewItems.length) {
+                return loadMore();
+              }
+            }
+          });
+        });
+      }).catch(function(err){
+        console.error('[rarity] loadMore failed', err);
+        uiError('Failed to load frogs.');
+      });
   }
 
-  function resort(userAddr){
-    view.sort((a,b)=> sortMode==='rank'
-      ? (a.rank - b.rank)
-      : ((b.score - a.score) || (a.rank - b.rank))
-    );
-    offset = 0; clearGrid(); loadMore(userAddr);
+  function resort() {
+    viewItems.sort(function(a, b){
+      var aRank = (a && a.rank != null) ? a.rank : Number.POSITIVE_INFINITY;
+      var bRank = (b && b.rank != null) ? b.rank : Number.POSITIVE_INFINITY;
+      if (sortMode === 'time') {
+        var aStaked = !!(a && a.staked);
+        var bStaked = !!(b && b.staked);
+        if (aStaked !== bStaked) {
+          return bStaked - aStaked;
+        }
+        var ta = (a && a.sinceMs != null) ? a.sinceMs : null;
+        var tb = (b && b.sinceMs != null) ? b.sinceMs : null;
+        if (ta == null && tb != null) return 1;
+        if (tb == null && ta != null) return -1;
+        if (ta != null && tb != null && ta !== tb) return ta - tb;
+        return aRank - bRank;
+      }
+      if (sortMode === 'score') {
+        var sa = (a && a.score != null) ? a.score : -Infinity;
+        var sb = (b && b.score != null) ? b.score : -Infinity;
+        var diff = (sb - sa);
+        if (diff) return diff;
+        return aRank - bRank;
+      }
+      return aRank - bRank;
+    });
+    offset = 0;
+    clearGrid();
+    loadMore();
   }
 
-  function jumpToId(id, userAddr){
-    const ix = view.findIndex(x => x.id === id);
+  function jumpToId(id) {
+    var ix = -1;
+    for (var i = 0; i < viewItems.length; i++) {
+      if (viewItems[i].id === id) { ix = i; break; }
+    }
     if (ix < 0) return;
     offset = Math.floor(ix / PAGE_SIZE) * PAGE_SIZE;
-    clearGrid(); loadMore(userAddr);
+    clearGrid();
+    loadMore();
   }
 
-  // ---------- Init ----------
-  (async function init(){
-    try{
-      rows = await loadRankings();
-      if (!rows.length){
-        GRID.innerHTML = `<div class="pg-muted" style="padding:10px">Could not load rarity data. Check JSON files and try a hard refresh.</div>`;
-        return;
+  function init() {
+    loadLookup().then(function(){
+      return loadPrimaryRanks();
+    }).then(function(primary){
+      if (primary && primary.length) {
+        allItems = primary;
+      } else if (lookupMap && lookupMap.size) {
+        allItems = Array.from(lookupMap).map(function(entry){
+          return { id: entry[0], rank: entry[1].rank, score: entry[1].score || 0 };
+        }).sort(function(a, b){ return a.rank - b.rank; });
+      } else {
+        uiError('Could not load rarity data. Check both JSON files\' shapes.');
+        return null;
       }
-      view = rows.slice();
-      offset = 0; clearGrid();
 
-      const userAddr = await getUserAddress();
-      await loadMore(userAddr);
-      BTN_MORE && (BTN_MORE.style.display = 'inline-flex');
+      viewItems = allItems.slice(0);
+      offset = 0;
+      clearGrid();
 
-      BTN_MORE?.addEventListener('click', () => loadMore(userAddr));
-      BTN_RANK?.addEventListener('click', ()=>{ sortMode='rank'; resort(userAddr); });
-      BTN_SCORE?.addEventListener('click', ()=>{ sortMode='score'; resort(userAddr); });
-      BTN_GO?.addEventListener('click', ()=>{
-        const id = Number(FIND_INPUT.value);
-        if (Number.isFinite(id)) jumpToId(id, userAddr);
+      return getUserAddress().then(function(addr){
+        currentUser = addr;
+        return loadMore();
+      });
+    }).then(function(){
+      if (BTN_MORE) BTN_MORE.style.display = 'inline-flex';
+
+      if (BTN_MORE) BTN_MORE.addEventListener('click', function(){ loadMore(); });
+      if (BTN_RANK) {
+        BTN_RANK.textContent = labelForSort('rank');
+        BTN_RANK.addEventListener('click', function(){ sortMode = 'rank'; resort(); });
+      }
+      if (BTN_SCORE) {
+        if (!SECOND_SORT_MODE) {
+          BTN_SCORE.style.display = 'none';
+        } else {
+          BTN_SCORE.textContent = SECOND_SORT_LABEL || labelForSort(SECOND_SORT_MODE);
+          BTN_SCORE.addEventListener('click', function(){ sortMode = SECOND_SORT_MODE; resort(); });
+        }
+      }
+      if (BTN_GO) BTN_GO.addEventListener('click', function(){
+        var id = Number(FIND_INPUT && FIND_INPUT.value);
+        if (isFinite(id)) jumpToId(id);
       });
 
-      if (window.ethereum?.on) window.ethereum.on('accountsChanged', ()=> location.reload());
-    }catch(e){
-      console.error('[rarity] init failed', e);
-      GRID.innerHTML = `<div class="pg-muted" style="padding:10px">Failed to initialize rarity view.</div>`;
-    }
-  })();
+      if (global.ethereum && typeof global.ethereum.on === 'function') {
+        global.ethereum.on('accountsChanged', function(){ global.location.reload(); });
+      }
+    }).catch(function(err){
+      console.error('[rarity] init error', err);
+      uiError('Failed to initialize rarity view. See console for details.');
+    });
+  }
 
-})(window.FF, window.FF_CFG);
+  initThemeCycle();
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})(window);

--- a/assets/js/topbar.js
+++ b/assets/js/topbar.js
@@ -68,7 +68,7 @@
       '<button class="btn btn-connected ffc-mutate" data-act="mutate">Mutate</button>';
 
     // Mount directly under the hero strip (title/small frogs)
-    var hero = $('.frog-hero');
+    var hero = document.querySelector('.ff-page-hero, .ff-hero, .frog-hero');
     if (hero && hero.parentNode) {
       if (hero.nextSibling) hero.parentNode.insertBefore(row, hero.nextSibling);
       else hero.parentNode.appendChild(row);

--- a/collection.html
+++ b/collection.html
@@ -1,237 +1,198 @@
 <!doctype html>
-<html lang="en" data-theme="t1">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>freshfrogs — Collection</title>
+  <title>Fresh Frogs — Collection dashboard</title>
 
   <link rel="stylesheet" href="assets/css/styles.css" />
-
-  <style>
-    /* Base */
-    .pg-wrap{ padding:20px; }
-    img{ image-rendering: pixelated; image-rendering: crisp-edges; }
-
-    .pg-card{ padding:14px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
-    .pg-card-head{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
-    .pg-card-head h3{ margin:0; font-weight:800; font-size:16px; }
-    .pg-muted{ color:var(--muted); font-size:13px; }
-
-    .list{ list-style:none; margin:0; padding:0; display:grid; gap:10px; }
-    .row{ display:grid; grid-template-columns:auto 1fr; gap:12px; align-items:center; padding:12px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
-    .thumb64{ width:64px; height:64px; min-width:64px; min-height:64px; border-radius:10px; object-fit:contain; background:var(--panel-2); }
-
-    /* Two-column page layout */
-    .page-grid{
-      display:grid; gap:16px; grid-template-columns: 1.2fr 0.8fr;
-      align-items:start; max-width:1100px; margin:0 auto;
-    }
-    @media (max-width:960px){ .page-grid{ grid-template-columns: 1fr; } }
-
-    /* Hero (centered) */
-    .frog-hero{ margin:28px auto 38px; max-width:1100px; }
-    .frog-title{ margin:0 0 6px 0; font:900 28px/1.15 'Space Grotesk', var(--font-ui); letter-spacing:-.01em; text-align:center; }
-    .frog-strip{ display:flex; gap:12px; align-items:center; justify-content:center; overflow:hidden; padding:0; }
-    .frog-strip .tile{ flex:0 0 auto; width:64px; height:64px; border-radius:10px; }
-    .frog-strip .tile.hide{ display:none !important; }
-    .frog-strip img{ width:64px; height:64px; object-fit:contain; }
-    @media (max-width:520px){ .frog-hero{ margin:22px auto 30px; } .frog-strip{ gap:10px; } }
-
-    /* Info blocks */
-    .info-grid-2{ display:grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap:10px; margin-bottom:10px; }
-    @media (max-width:900px){ .info-grid-2{ grid-template-columns: repeat(2, minmax(0,1fr)); } }
-    @media (max-width:520px){ .info-grid-2{ grid-template-columns: 1fr; } }
-    .info-block{ border:1px solid var(--border); border-radius:12px; padding:10px; background:var(--panel); }
-    .info-block .ik{ font-size:11px; color:var(--muted); letter-spacing:.04em; text-transform:uppercase; }
-    .info-block .iv{ font-weight:900; font-size:18px; line-height:1.1; margin-top:4px; }
-    .info-block .in{ font-size:12px; color:var(--muted); }
-
-    /* Scrollable list (Recent Stakes) */
-    #recentStakes.scrolling{ overflow-y:auto; -webkit-overflow-scrolling:touch; padding-right:4px; }
-    #recentStakes .row{ cursor:pointer; }
-    @media (hover:hover){
-      #recentStakes.scrolling::-webkit-scrollbar{ width:8px; }
-      #recentStakes.scrolling::-webkit-scrollbar-thumb{
-        background: color-mix(in srgb, var(--muted) 35%, transparent);
-        border-radius:8px;
-      }
-    }
-
-    /* Cards (Owned Frogs) */
-    #ownedCard .grid-cards{ display:grid; gap:10px; grid-template-columns: 1fr; }
-    .frog-card{
-      border:1px solid var(--border);
-      background: var(--panel);
-      border-radius:14px;
-      padding:12px;
-      display:grid; grid-template-columns:auto 1fr; column-gap:12px; row-gap:6px; align-items:start;
-      color:inherit;
-    }
-    .frog-card .thumb{
-      width:128px;height:128px;border-radius:12px;background:var(--panel-2);object-fit:contain;grid-row: span 3;
-      box-shadow: inset 0 0 0 1px rgba(255,255,255,.06), 0 6px 12px rgba(0,0,0,.25);
-    }
-    .title{ margin:0; font-weight:900; font-size:18px; letter-spacing:-.01em; display:flex; align-items:center; gap:8px; }
-    .pill{ display:inline-block; padding:3px 10px; border-radius:999px; background: color-mix(in srgb, var(--panel) 85%, transparent); border:1px solid var(--border); font-size:12px; }
-    .meta{ color:var(--muted); font-size:12px; }
-    .actions{ grid-column:1 / -1; display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
-    .btn{
-      font-family: var(--font-ui);
-      border:1px solid var(--border);
-      background:transparent;
-      color:inherit;
-      border-radius:8px;
-      padding:6px 10px;
-      font-weight:700;
-      font-size:12px;
-      line-height:1;
-      display:inline-flex; align-items:center; gap:6px;
-      text-decoration:none; letter-spacing:.01em;
-      transition: background .15s ease, border-color .15s ease, color .15s ease, transform .05s ease;
-    }
-    .btn:active{ transform: translateY(1px); }
-    .btn-outline-gray{ border-color: color-mix(in srgb, #9ca3af 70%, var(--border)); color: color-mix(in srgb, #ffffff 65%, #9ca3af); }
-    #ownedCard .actions .btn:hover{
-      background: color-mix(in srgb, #22c55e 14%, var(--panel));
-      border-color: color-mix(in srgb, #22c55e 80%, var(--border));
-      color: color-mix(in srgb, #ffffff 85%, #22c55e);
-    }
-    /* Let long addresses wrap instead of hard-truncating on desktop */
-    #recentStakes .pg-muted { 
-      white-space: normal;
-      word-break: break-all;   /* allows 0x… addresses to wrap cleanly */
-    }
-    .kpi{display:inline-grid;gap:4px;margin:8px 12px 0 0}
-    .kpi-label{font-size:.9rem;color:var(--muted,#97a0b2)}
-    .kpi-value{font-weight:700}
-
-  </style>
 </head>
-<body>
-  <div class="pg-wrap container">
-    <!-- HERO -->
-    <section class="frog-hero">
-      <h1 class="frog-title">freshfrogs.github.io</h1>
-      <div class="frog-strip">
-        <div class="tile"><img src="frog/12.png"  alt="12"></div>
-        <div class="tile"><img src="frog/77.png"  alt="77"></div>
-        <div class="tile"><img src="frog/404.png" alt="404"></div>
-        <div class="tile"><img src="frog/256.png" alt="256"></div>
-        <div class="tile"><img src="frog/999.png" alt="999"></div>
-        <div class="tile"><img src="frog/1.png"   alt="1"></div>
+<body class="ff-body">
+  <div class="ff-site">
+    <header class="ff-masthead">
+      <div class="ff-container ff-masthead__inner">
+        <a class="ff-logo" href="index.html"><span>🐸</span>Fresh Frogs</a>
+        <nav class="ff-nav" aria-label="Primary">
+          <a href="collection.html" aria-current="page">Collection</a>
+          <a href="rarity.html">Rarity</a>
+          <a href="pond.html">Pond</a>
+          <a href="mutate.html">Mutate</a>
+        </nav>
+        <a class="ff-button ff-button--ghost" href="rarity.html">Compare rarity</a>
       </div>
-    </section>
-    <div id="ffTopbarMount"></div>
+    </header>
 
-    <!-- GRID -->
-    <div class="page-grid">
-
-      <!-- Left: The Pond (activity + KPIs) -->
-      <section class="pg-card">
-        <div class="pg-card-head"><h3>The Pond</h3></div>
-          <p class="pg-muted" style="margin:6px 0 12px 0; max-width:70ch;">
-            Live view of staking activity in the FreshFrogs pond — track total staked, the controller contract, and FLYZ rewards.
-          </p>
-
-        <!-- KPIs -->
-        <div class="info-grid-2" style="margin-bottom:10px;">
-          <!-- 1) Total Frogs Staked (emoji changed) -->
-          <div class="info-block">
-            <div class="ik">🌿 Total Frogs Staked</div>
-            <div class="iv" id="stakedTotal">—</div>
-            <div class="in">Across the collection</div>
-          </div>
-
-          <!-- 2) Controller (unchanged) -->
-          <div class="info-block">
-            <div class="ik">🧰 Controller</div>
-            <div class="iv">
-              <a id="stakedController" href="#" target="_blank" rel="noopener">—</a>
+    <main class="ff-main">
+      <section class="ff-page-hero">
+        <div class="ff-container ff-page-hero__inner">
+          <div>
+            <span class="ff-eyebrow">Dashboard</span>
+            <h1 class="ff-page-hero__title">Command center for your frogs</h1>
+            <p class="ff-page-hero__lead">
+              Track staking rewards, view ownership status, and manage every frog in your wallet from a single responsive hub.
+              The dashboard mirrors live blockchain data so you always act on the latest state.
+            </p>
+            <div class="ff-page-hero__meta">
+              <span class="ff-pill">4,040 total supply</span>
+              <span class="ff-pill">Stake to earn $FLYZ</span>
+              <span class="ff-pill">Controller <span class="addr">0x7dfb…f1b2</span></span>
             </div>
-            <div class="in">Staking contract</div>
           </div>
-
-          <!-- 3) Rewards with emoji + link to FLYZ -->
-          <div class="info-block">
-            <div class="ik">🪙 Rewards</div>
-            <div class="iv">
-              <a id="pondRewardsLink" href="https://etherscan.io/token/0xd71d2f57819ae4be6924a36591ec6c164e087e63" target="_blank" rel="noopener">
-                <span id="pondRewardsSymbol">$FLYZ</span>
-              </a>
+          <div class="ff-hero__media">
+            <div class="ff-card-stack">
+              <div class="ff-card-stack__layer" data-layer="1">
+                <img data-dashboard-frog="1" src="frog/11.png" alt="Frog 11" />
+                <p class="ff-card-stack__label">Manage staking, transfers, and approvals with layered card controls.</p>
+              </div>
+              <div class="ff-card-stack__layer" data-layer="2">
+                <img data-dashboard-frog="2" src="frog/256.png" alt="Frog 256" />
+              </div>
+              <div class="ff-card-stack__layer" data-layer="3">
+                <img data-dashboard-frog="3" src="frog/999.png" alt="Frog 999" />
+              </div>
             </div>
-            <div class="in">Earnings token</div>
           </div>
-
         </div>
-
-        <!-- Recent Stakes (scrollable) -->
-        <ul id="recentStakes" class="list" aria-live="polite" data-visible="6">
-          <li class="row"><div class="pg-muted">Loading recent stakes…</div></li>
-        </ul>
       </section>
 
-      <!-- Right: My Frogs (header + cards) -->
-      <section id="ownedCard" class="pg-card">
-        <div class="pg-card-head">
-          <h3>Dashboard</h3>
-          <div id="ownedWalletAddr" class="dash-addr" style="display:none;"></div>
-        </div>
+      <div class="ff-container" id="ffTopbarMount"></div>
 
-        <!-- Header for KPIs is injected by owned-panel.js; remove old info squares -->
+      <section class="ff-page-content">
+        <div class="ff-container">
+          <div class="ff-page-grid">
+            <div class="ff-main-panel">
+              <section class="ff-panel" aria-labelledby="pondOverviewTitle">
+                <div>
+                  <h2 id="pondOverviewTitle">The pond at a glance</h2>
+                  <p class="muted">Live staking metrics and controller details pulled directly from the Fresh Frogs contracts.</p>
+                </div>
+                <dl class="ff-stat-bar">
+                  <div class="ff-stat"><dt>Total frogs staked</dt><dd id="stakedTotal">—</dd></div>
+                  <div class="ff-stat"><dt>Controller</dt><dd><a id="stakedController" href="#" target="_blank" rel="noopener">—</a></dd></div>
+                  <div class="ff-stat"><dt>Rewards token</dt><dd><a id="pondRewardsLink" href="#" target="_blank" rel="noopener"><span id="pondRewardsSymbol">$FLYZ</span></a></dd></div>
+                  <div class="ff-stat"><dt>Latest activity</dt><dd id="pondLatest">Updating…</dd></div>
+                </dl>
+                <ul id="recentStakes" class="ff-feed" aria-live="polite" data-visible="5">
+                  <li class="row"><div class="pg-muted">Loading recent stakes…</div></li>
+                </ul>
+              </section>
 
-        <div class="grid-cards" id="ownedGrid">
-          <div class="pg-muted">Connect your wallet to view owned frogs.</div>
+              <section id="ownedCard" class="ff-panel" aria-labelledby="ownedPanelTitle">
+                <div class="ff-toolbar">
+                  <div class="ff-toolbar__group">
+                    <h2 id="ownedPanelTitle" style="margin:0;">Your frogs</h2>
+                    <p class="muted" style="margin:0; max-width:32ch;">Connect your wallet to fetch owned tokens, staking status, and claimable rewards.</p>
+                  </div>
+                  <button id="ownedConnectBtn" class="ff-button ff-button--solid">Connect wallet</button>
+                </div>
+                <div class="ff-grid" id="ownedGrid">
+                  <div class="ff-empty">Connect your wallet to view owned frogs.</div>
+                </div>
+                <div class="ff-toolbar" style="justify-content:center; display:none;" id="ownedMore">Loading more…</div>
+              </section>
+            </div>
+
+            <aside class="ff-side-panel">
+              <section class="ff-panel" aria-labelledby="activityTitle">
+                <div>
+                  <h2 id="activityTitle">Activity highlights</h2>
+                  <p class="muted">Quick links to staking guides, contract addresses, and support resources.</p>
+                </div>
+                <ul class="ff-list-compact">
+                  <li>
+                    <strong>Need help staking?</strong>
+                    <span class="meta">Review the step-by-step staking walkthrough from the docs.</span>
+                  </li>
+                  <li>
+                    <strong>Controller contract</strong>
+                    <span class="meta"><a id="controllerLink" href="#" target="_blank" rel="noopener">View on Etherscan</a></span>
+                  </li>
+                  <li>
+                    <strong>Reward token</strong>
+                    <span class="meta"><a href="https://etherscan.io/token/0xd71d2f57819ae4be6924a36591ec6c164e087e63" target="_blank" rel="noopener">$FLYZ contract</a></span>
+                  </li>
+                </ul>
+              </section>
+            </aside>
+          </div>
         </div>
-        <div class="pg-muted" id="ownedMore" style="margin-top:8px; text-align:center; display:none;">Loading more…</div>
       </section>
+    </main>
 
-    </div>
+    <footer class="ff-footer">
+      <div class="ff-container ff-footer__inner">
+        <span>© Fresh Frogs</span>
+        <span>Stake, claim rewards, and evolve your collection.</span>
+      </div>
+    </footer>
   </div>
 
   <script>
-    /* Hero strip: keep whole 64px tiles only */
-    function layoutFrogStrip(){
-      var strip = document.querySelector('.frog-strip'); if(!strip) return;
-      var tiles = Array.prototype.slice.call(strip.querySelectorAll('.tile'));
-      var styles = window.getComputedStyle(strip);
-      var gap = parseFloat(styles.gap || 12) || 12;
-      var tileW = 64, innerW = strip.clientWidth;
-      var count = Math.max(1, Math.floor((innerW + gap) / (tileW + gap)));
-      tiles.forEach(function(t,i){ t.classList.toggle('hide', i >= count); });
-    }
-    window.addEventListener('resize', layoutFrogStrip);
-    document.addEventListener('DOMContentLoaded', layoutFrogStrip);
+    (function(){
+      const CFG = window.FF_CFG || {};
+      const TOTAL = Number(CFG.TOTAL_SUPPLY || 4040);
+      const ROOT  = String(CFG.SOURCE_PATH || '').replace(/\/+$/,'');
+      function pick(n,max){
+        const pool = Array.from({length:max}, (_,i)=> i+1);
+        for(let i=pool.length-1;i>0;i--){
+          const j=Math.floor(Math.random()*(i+1));
+          const tmp=pool[i]; pool[i]=pool[j]; pool[j]=tmp;
+        }
+        return pool.slice(0,n);
+      }
+      function randomize(){
+        const imgs = Array.from(document.querySelectorAll('[data-dashboard-frog]'));
+        if(!imgs.length) return;
+        const ids = pick(imgs.length, TOTAL);
+        imgs.forEach(function(img, idx){
+          const id = ids[idx];
+          img.src = ROOT + '/frog/' + id + '.png';
+          img.alt = 'Frog ' + id;
+        });
+      }
+      if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', randomize); else randomize();
+    })();
   </script>
 
-<!-- Config & shared helpers -->
-<script src="https://cdn.jsdelivr.net/npm/web3@1.10.4/dist/web3.min.js"></script>
-<script src="assets/js/config.js"></script>
-<script src="assets/js/utils.js"></script>
-<script src="assets/js/rarity.js"></script>
-<script src="assets/js/modal.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/web3@1.10.4/dist/web3.min.js"></script>
+  <script src="assets/js/config.js"></script>
+  <script src="assets/js/utils.js"></script>
+  <script src="assets/js/rarity.js"></script>
+  <script src="assets/js/modal.js"></script>
+  <script src="assets/abi/collection_abi.js"></script>
+  <script src="assets/abi/controller_abi.js"></script>
+  <script src="assets/js/pond.js"></script>
+  <script src="assets/js/wallet-state.js"></script>
+  <script src="assets/js/wallet.js"></script>
+  <script src="assets/js/staking-adapter.js"></script>
+  <script src="assets/js/pond-kpis.js"></script>
+  <script src="assets/js/topbar.js"></script>
+  <script src="assets/js/frog-renderer.js"></script>
+  <script src="assets/js/frog-cards.js" defer></script>
+  <script src="assets/js/stakes-feed.js"></script>
+  <script src="assets/js/pond-tweaks.js"></script>
+  <script src="assets/js/owned-panel.js"></script>
+  <script src="assets/js/frog-thumbs.js"></script>
 
-<!-- ABIs must come from /assets/abi -->
-<script src="assets/abi/collection_abi.js"></script>
-<script src="assets/abi/controller_abi.js"></script>
+  <script>
+    if (window.FF_loadRecentStakes) FF_loadRecentStakes();
+    if (window.FF_initOwnedPanel)   FF_initOwnedPanel();
+  </script>
 
-<!-- Panels / features (all from /assets/js) -->
-<script src="assets/js/pond.js"></script>
-<script src="assets/js/wallet-state.js"></script>
-<script src="assets/js/wallet.js"></script>
-<script src="assets/js/staking-adapter.js"></script>  <!-- ✅ correct path -->
-<script src="assets/js/pond-kpis.js"></script>
-<script src="assets/js/topbar.js"></script>
-<script src="assets/js/frog-renderer.js"></script>
-<script src="assets/js/frog-cards.js" defer></script>
-<script src="assets/js/stakes-feed.js"></script>
-<script src="assets/js/pond-tweaks.js"></script>
-<script src="assets/js/owned-panel.js"></script>
-<script src="assets/js/frog-thumbs.js"></script>
-
-<script>
-  if (window.FF_loadRecentStakes) FF_loadRecentStakes();
-  if (window.FF_initOwnedPanel)   FF_initOwnedPanel();
-</script>
-
+  <script>
+    (function(){
+      const cfg = window.FF_CFG || {};
+      const addr = (cfg.CONTROLLER_ADDRESS || '').trim();
+      const link = document.getElementById('controllerLink');
+      if (!link || !addr) return;
+      const chain = Number(cfg.CHAIN_ID || 1);
+      let base = 'https://etherscan.io/address/';
+      if (chain === 11155111) base = 'https://sepolia.etherscan.io/address/';
+      else if (chain === 5) base = 'https://goerli.etherscan.io/address/';
+      link.href = base + addr;
+      link.textContent = addr.slice(0,6) + '…' + addr.slice(-4);
+      link.setAttribute('data-addr', addr);
+    })();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,159 +1,181 @@
 <!doctype html>
-<html lang="en" data-theme="t1">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>freshfrogs.github.io — Layout 3</title>
+  <title>Fresh Frogs — Collect, stake, and evolve</title>
 
   <link rel="stylesheet" href="assets/css/styles.css" />
-
-  <style>
-    /* Base */
-    .pg-wrap{ padding:20px; }
-    img{ image-rendering: pixelated; image-rendering: crisp-edges; }
-
-    .pg-card{ padding:14px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
-    .pg-card-head{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
-    .pg-card-head h3{ margin:0; font-weight:800; font-size:16px; }
-    .pg-muted{ color:var(--muted); font-size:13px; }
-
-    .list{ list-style:none; margin:0; padding:0; display:grid; gap:10px; }
-    .row{ display:grid; grid-template-columns:auto 1fr; gap:12px; align-items:center; padding:12px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
-    .thumb64{ width:64px; height:64px; min-width:64px; min-height:64px; border-radius:10px; object-fit:contain; background:var(--panel-2); }
-
-    /* Centered single-panel layout (fixed width) */
-    :root{ --panel-width: 640px; }
-    .center-wrap{ display:grid; gap:16px; justify-items:center; }
-    .centered-card{ width: min(var(--panel-width), 100%); }
-
-    /* Hero (centered) */
-    .frog-hero{ margin:28px auto 38px; width: min(var(--panel-width), 100%); }
-    .frog-title{ margin:0 0 6px 0; font:900 28px/1.15 'Space Grotesk', var(--font-ui); letter-spacing:-.01em; text-align:center; }
-    .frog-strip{ display:flex; gap:12px; align-items:center; justify-content:center; overflow:hidden; padding:0; }
-    .frog-strip .tile{ flex:0 0 auto; width:64px; height:64px; border-radius:10px; }
-    .frog-strip .tile.hide{ display:none !important; }
-    .frog-strip img{ width:64px; height:64px; object-fit:contain; }
-    @media (max-width:520px){ .frog-hero{ margin:22px auto 30px; } .frog-strip{ gap:10px; } }
-
-    /* Info blocks */
-    .info-grid-2{ display:grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap:10px; margin-bottom:10px; }
-    @media (max-width:900px){ .info-grid-2{ grid-template-columns: repeat(2, minmax(0,1fr)); } }
-    @media (max-width:520px){ .info-grid-2{ grid-template-columns: 1fr; } }
-    .info-block{ border:1px solid var(--border); border-radius:12px; padding:10px; background:var(--panel); }
-    .info-block .ik{ font-size:11px; color:var(--muted); letter-spacing:.04em; text-transform:uppercase; }
-    .info-block .iv{ font-weight:900; font-size:18px; line-height:1.1; margin-top:4px; }
-    .info-block .in{ font-size:12px; color:var(--muted); }
-
-    /* Mint (Mini) */
-    #mintMini.mint-mini{
-      border:1px solid var(--border); border-radius:12px; background: var(--panel);
-      padding:10px; margin:8px 0 12px;
-    }
-    #mintMini .mint-mini__row{ display:grid; grid-template-columns:auto auto 1fr auto; align-items:center; gap:10px; }
-    #mintMini .mint-mini__price{ border:1px solid var(--border); border-radius:10px; padding:8px 10px; background: color-mix(in srgb, var(--panel) 90%, transparent); display:grid; grid-template-columns:auto auto; gap:6px 8px; align-items:baseline; }
-    #mintMini .mint-mini__price .k{ font-size:12px; color:var(--muted); }
-    #mintMini .mint-mini__price .v{ font-weight:900; font-size:14px; }
-    #mintMini .mint-mini__stepper{ display:flex; align-items:center; gap:8px; }
-    #mintMini .mini__btn{ width:28px; height:28px; border-radius:8px; border:1px solid var(--border); background:transparent; color:inherit; font-weight:800; line-height:1; display:grid; place-items:center; }
-    #mintMini .mini__btn:active{ transform: translateY(1px); }
-    #mintMini .mini__qty{ width:64px; text-align:center; padding:6px; border-radius:8px; border:1px solid var(--border); background:transparent; color:inherit; font-family:var(--font-ui); }
-    #mintMini .mini__mint{ padding-inline:12px; }
-    #mintMini .mint-mini__total{ font-size:12px; color:var(--muted); justify-self:end; }
-    #mintMini .mint-mini__note{ margin-top:6px; font-size:12px; }
-    @media (max-width:600px){ #mintMini .mint-mini__row{ grid-template-columns: 1fr 1fr; } #mintMini .mint-mini__total{ justify-self:start; } }
-
-    /* Scrollable lists: JS sets max-height to N rows; infinite scroll appends */
-    #recentMints.scrolling,
-    #recentStakes.scrolling{
-      overflow-y:auto;
-      -webkit-overflow-scrolling:touch;
-      padding-right:4px;
-    }
-    #recentMints .row, #recentStakes .row{ cursor:pointer; }
-    @media (hover:hover){
-      #recentMints.scrolling::-webkit-scrollbar,
-      #recentStakes.scrolling::-webkit-scrollbar{ width:8px; }
-      #recentMints.scrolling::-webkit-scrollbar-thumb,
-      #recentStakes.scrolling::-webkit-scrollbar-thumb{
-        background: color-mix(in srgb, var(--muted) 35%, transparent);
-        border-radius:8px;
-      }
-    }
-  </style>
 </head>
-<body>
-  <div class="pg-wrap container">
-    <div class="center-wrap">
+<body class="ff-body">
+  <div class="ff-site">
+    <header class="ff-masthead">
+      <div class="ff-container ff-masthead__inner">
+        <a class="ff-logo" href="index.html"><span>🐸</span>Fresh Frogs</a>
+        <nav class="ff-nav" aria-label="Primary">
+          <a href="collection.html">Collection</a>
+          <a href="rarity.html">Rarity</a>
+          <a href="pond.html">Pond</a>
+          <a href="mutate.html">Mutate</a>
+        </nav>
+        <a class="ff-button ff-button--ghost" href="collection.html">Enter app</a>
+      </div>
+    </header>
 
-      <!-- HERO -->
-      <section class="frog-hero">
-        <h1 class="frog-title">freshfrogs.github.io</h1>
-        <div class="frog-strip">
-          <div class="tile"><img src="frog/12.png"  alt="12"></div>
-          <div class="tile"><img src="frog/77.png"  alt="77"></div>
-          <div class="tile"><img src="frog/404.png" alt="404"></div>
-          <div class="tile"><img src="frog/256.png" alt="256"></div>
-          <div class="tile"><img src="frog/999.png" alt="999"></div>
-          <div class="tile"><img src="frog/1.png"   alt="1"></div>
-        </div>
-      </section>
-
-      <!-- Fresh Frogs NFT -->
-      <section class="pg-card centered-card">
-        <div class="pg-card-head"><h3>Fresh Frogs NFT</h3></div>
-        <p class="pg-muted" style="margin:6px 0 12px 0; max-width:70ch;">
-          Pixel-perfect frogs hopping around the Ethereum pond. Mint, stake to earn FLYZ, and explore the collection’s quirks and traits.
-        </p>
-
-        <div class="info-grid-2">
-          <div class="info-block"><div class="ik">🐸 Supply</div><div class="iv">4,040</div><div class="in">Total tokens</div></div>
-          <div class="info-block"><div class="ik">⛓️ Chain</div><div class="iv">Ethereum</div><div class="in">ERC-721</div></div>
-          <div class="info-block"><div class="ik">🎧 Royalty</div><div class="iv">5%</div><div class="in">Secondary sales</div></div>
-          <div class="info-block"><div class="ik">🪙 Mint</div><div class="iv">0.01 ETH</div><div class="in">Per frog</div></div>
-        </div>
-
-        <!-- Mint (Mini) -->
-        <section id="mintMini" class="mint-mini" aria-label="Quick mint">
-          <div class="mint-mini__row">
-            <div class="mint-mini__price">
-              <div class="k">Price</div><div class="v">0.01 ETH</div>
+    <main class="ff-main">
+      <section class="ff-hero">
+        <div class="ff-container ff-hero__inner">
+          <div class="ff-hero__content">
+            <span class="ff-eyebrow">Ethereum collection</span>
+            <h1 class="ff-headline">Collect, stake, and evolve Fresh Frogs</h1>
+            <p class="ff-hero__lead">
+              Fresh Frogs is a hand-crafted set of 4,040 pixel amphibians. Stake your frog to earn $FLYZ,
+              hunt for legendary traits, and combine attributes to mint custom mutations.
+            </p>
+            <div class="ff-hero__actions">
+              <a class="ff-button ff-button--solid" href="collection.html">Explore collection</a>
+              <a class="ff-button" href="rarity.html">View rarity rankings</a>
             </div>
-
-            <div class="mint-mini__stepper" role="group" aria-label="Quantity">
-              <button type="button" class="mini__btn" data-delta="-1" aria-label="Decrease">−</button>
-              <input id="miniQty" class="mini__qty" type="text" inputmode="numeric" pattern="[0-9]*" value="1" aria-label="Quantity">
-              <button type="button" class="mini__btn" data-delta="1" aria-label="Increase">+</button>
-            </div>
-
-            <button type="button" class="btn mini__mint">Mint</button>
-            <div class="mint-mini__total">Total: <b id="miniTotal">0.01 ETH</b></div>
+            <dl class="ff-stat-bar">
+              <div class="ff-stat"><dt>Supply</dt><dd>4,040</dd></div>
+              <div class="ff-stat"><dt>Staking rewards</dt><dd>$FLYZ / day</dd></div>
+              <div class="ff-stat"><dt>Controller</dt><dd class="addr">0x7dfb…f1b2</dd></div>
+            </dl>
           </div>
-          <div class="mint-mini__note pg-muted">Connect wallet to mint.</div>
-        </section>
-
-        <!-- Recent Mints -->
-        <ul id="recentMints" class="list" aria-live="polite" data-visible="6">
-          <li class="row"><div class="pg-muted">Loading recent mints…</div></li>
-        </ul>
+          <div class="ff-hero__media">
+            <div class="ff-card-stack">
+              <div class="ff-card-stack__layer" data-layer="1">
+                <img data-hero-frog="1" src="frog/12.png" alt="Frog 12" />
+                <p class="ff-card-stack__label">Legendary traits, layered animations, and collectible card frames.</p>
+              </div>
+              <div class="ff-card-stack__layer" data-layer="2">
+                <img data-hero-frog="2" src="frog/404.png" alt="Frog 404" />
+              </div>
+              <div class="ff-card-stack__layer" data-layer="3">
+                <img data-hero-frog="3" src="frog/77.png" alt="Frog 77" />
+              </div>
+            </div>
+          </div>
+        </div>
       </section>
-    </div>
+
+      <section class="ff-section">
+        <div class="ff-container">
+          <div class="ff-section__head">
+            <span class="ff-eyebrow">Why Fresh Frogs?</span>
+            <h2 class="ff-section__title">A world of utility packed into pixel-perfect collectibles</h2>
+            <p class="ff-section__intro">From on-chain rarity data to live staking dashboards, the Fresh Frogs hub keeps every holder in the loop.</p>
+          </div>
+          <div class="ff-feature-grid">
+            <article class="ff-feature-card">
+              <h3>Stake to earn</h3>
+              <p>Lock your frogs into the pond to accrue $FLYZ rewards, unlock levels, and climb the staking leaderboard.</p>
+            </article>
+            <article class="ff-feature-card">
+              <h3>Live rarity intelligence</h3>
+              <p>Track rarity ranks, trait combos, and real owner data with a responsive interface designed for collectors.</p>
+            </article>
+            <article class="ff-feature-card">
+              <h3>Mutations &amp; mashups</h3>
+              <p>Combine two parent frogs to build a custom hybrid with inherited metadata and animated layers.</p>
+            </article>
+            <article class="ff-feature-card">
+              <h3>On-chain provenance</h3>
+              <p>Each frog is sourced directly from our verified contract and IPFS metadata, ensuring authenticity forever.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="ff-section ff-section--alt">
+        <div class="ff-container">
+          <div class="ff-panel-grid">
+            <div class="ff-panel">
+              <h2>Mint directly from the pond</h2>
+              <p>Choose your quantity, preview the total, and mint instantly when the drop is live. Connect a wallet to get started.</p>
+
+              <section id="mintMini" class="mint-mini" aria-label="Quick mint">
+                <div class="mint-mini__row">
+                  <div class="mint-mini__price">
+                    <div class="k">Price</div><div class="v">0.01 ETH</div>
+                  </div>
+
+                  <div class="mint-mini__stepper" role="group" aria-label="Quantity">
+                    <button type="button" class="mini__btn" data-delta="-1" aria-label="Decrease quantity">−</button>
+                    <input id="miniQty" class="mini__qty" type="text" inputmode="numeric" pattern="[0-9]*" value="1" aria-label="Quantity">
+                    <button type="button" class="mini__btn" data-delta="1" aria-label="Increase quantity">+</button>
+                  </div>
+
+                  <button type="button" class="ff-button ff-button--solid mini__mint">Mint</button>
+                  <div class="mint-mini__total">Total: <b id="miniTotal">0.01 ETH</b></div>
+                </div>
+                <div class="mint-mini__note muted">Connect wallet to mint.</div>
+              </section>
+
+              <div class="stack">
+                <h3 class="section-title">Recent mints</h3>
+                <ul id="recentMints" class="ff-feed" aria-live="polite" data-visible="6">
+                  <li class="row"><div class="pg-muted">Loading recent mints…</div></li>
+                </ul>
+              </div>
+            </div>
+
+            <aside class="ff-panel">
+              <h2>Live from the staking pond</h2>
+              <p class="muted">See who is staking, unstaking, and moving frogs around the ecosystem in real time.</p>
+              <ul id="recentStakes" class="ff-feed" aria-live="polite" data-visible="6">
+                <li class="row"><div class="pg-muted">Loading staking activity…</div></li>
+              </ul>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section class="ff-section">
+        <div class="ff-container">
+          <div class="ff-section__head">
+            <span class="ff-eyebrow">How it works</span>
+            <h2 class="ff-section__title">Three easy steps to join the pond</h2>
+            <p class="ff-section__intro">Collect, stake, and experiment with your frogs using the streamlined Fresh Frogs dashboard.</p>
+          </div>
+          <div class="ff-step-grid">
+            <article class="ff-step">
+              <h3>1. Mint or buy a frog</h3>
+              <p>Grab a freshly minted frog or scoop one from the secondary market. Each frog comes with unique layered traits.</p>
+            </article>
+            <article class="ff-step">
+              <h3>2. Stake to earn $FLYZ</h3>
+              <p>Send your frog to the staking pond to accumulate daily rewards, unlock levels, and reveal time-based badges.</p>
+            </article>
+            <article class="ff-step">
+              <h3>3. Combine &amp; mutate</h3>
+              <p>When inspiration strikes, fuse two parents to craft a custom mutation with inherited metadata and animations.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="ff-cta">
+        <div class="ff-container ff-cta__inner">
+          <h2>Ready to dive into the pond?</h2>
+          <p>Browse rarity ranks, manage your staking positions, and experiment with mutations — all from the Fresh Frogs dashboard.</p>
+          <div class="ff-cta__actions">
+            <a class="ff-button ff-button--solid" href="collection.html">Open the collection app</a>
+            <a class="ff-button" href="rarity.html">Compare rarity cards</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="ff-footer">
+      <div class="ff-container ff-footer__inner">
+        <span>© Fresh Frogs</span>
+        <span>Made for the community — stake, earn, and evolve.</span>
+      </div>
+    </footer>
   </div>
 
   <script>
-    /* Keep whole 64px tiles only (hero strip) */
-    function layoutFrogStrip(){
-      var strip = document.querySelector('.frog-strip'); if(!strip) return;
-      var tiles = Array.prototype.slice.call(strip.querySelectorAll('.tile'));
-      var styles = window.getComputedStyle(strip);
-      var gap = parseFloat(styles.gap || 12) || 12;
-      var tileW = 64, innerW = strip.clientWidth;
-      var count = Math.max(1, Math.floor((innerW + gap) / (tileW + gap)));
-      tiles.forEach(function(t,i){ t.classList.toggle('hide', i >= count); });
-    }
-    window.addEventListener('resize', layoutFrogStrip);
-    document.addEventListener('DOMContentLoaded', layoutFrogStrip);
-
-    /* Mint (Mini): stepper + totals */
     (function(){
       var PRICE = 0.01;
       function clamp(n){ n = parseInt(n||'1', 10); return isNaN(n) ? 1 : Math.max(1, n); }
@@ -199,49 +221,39 @@
   </script>
 
   <script>
-  // Randomize the hero frog images on each load.
   (function () {
     const CFG = window.FF_CFG || {};
     const TOTAL = Number(CFG.TOTAL_SUPPLY || 4040);
-    const ROOT  = String(CFG.SOURCE_PATH || '').replace(/\/+$/,'') || '';
+    const ROOT  = String(CFG.SOURCE_PATH || '').replace(/\/+$/,'');
 
     function pickUniqueIds(n, max){
-      // Fisher–Yates shuffle of a small sample for uniqueness
       const pool = Array.from({length:max}, (_,i)=> i+1);
       for (let i = pool.length - 1; i > 0; i--){
         const j = Math.floor(Math.random()*(i+1));
-        [pool[i], pool[j]] = [pool[j], pool[i]];
+        const tmp = pool[i]; pool[i] = pool[j]; pool[j] = tmp;
       }
       return pool.slice(0, n);
     }
 
-    function randomizeStrip(selector){
-      const strip = document.querySelector(selector);
-      if (!strip) return;
-      const imgs = Array.from(strip.querySelectorAll('.tile img'));
+    function randomizeCards(){
+      const imgs = Array.from(document.querySelectorAll('[data-hero-frog]'));
       if (!imgs.length) return;
-
       const ids = pickUniqueIds(imgs.length, TOTAL);
-      imgs.forEach((img, idx) => {
+      imgs.forEach(function(img, idx){
         const id = ids[idx];
         img.src = ROOT + '/frog/' + id + '.png';
-        img.alt = String(id);
+        img.alt = 'Frog ' + id;
       });
     }
 
-    function init(){
-      randomizeStrip('.frog-strip');
-      // If you have a layout function on this page, call it after randomizing
-      if (typeof layoutFrogStrip === 'function') {
-        layoutFrogStrip();
-      }
+    function init(){ randomizeCards(); }
+
+    if (document.readyState === 'loading'){
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
     }
-
-    (document.readyState === 'loading')
-      ? document.addEventListener('DOMContentLoaded', init)
-      : init();
   })();
-</script>
-
+  </script>
 </body>
 </html>

--- a/mutate.html
+++ b/mutate.html
@@ -1,162 +1,147 @@
 <!doctype html>
-<html lang="en" data-theme="t1">
+<html lang="en" data-theme="atlas">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>freshfrogs — Mutate</title>
+  <title>Fresh Frogs — Mutations lab</title>
 
-  <!-- site styles -->
   <link rel="stylesheet" href="assets/css/styles.css" />
 
   <style>
-    /* ===== Mutate page layout (scoped) ===== */
-    :root { color-scheme: dark; }
-
-    #mutateCenter{
-      /* bulletproof centering */
-      min-height: 100svh;
-      display: grid;
-      place-items: center;
-      padding: 24px;
-      width: 100%;
-    }
-
-    #mutatePage{
-      width: min(1100px, 96vw);
-      background: var(--panel,#0e1117);
-      border: 1px solid var(--border, rgba(255,255,255,.08));
-      border-radius: 16px;
-      box-shadow: 0 18px 42px rgba(0,0,0,.35);
-      overflow: hidden;
-    }
-
-    .mutate-grid{
-      display: grid;
-      grid-template-columns: 420px 1fr; /* frog | info */
-      gap: 28px;
-      padding: 24px;
-    }
-
-    /* Stack on small screens */
-    @media (max-width: 860px){
-      .mutate-grid{ grid-template-columns: 1fr; }
-    }
-
-    /* Left column */
-    .mutate-left{
-      display: grid;
-      grid-template-rows: auto auto;
-      gap: 16px;
-      align-content: start;
-    }
-
-    .mutate-card{
-      background: #0f1320;
-      border: 1px solid rgba(255,255,255,.06);
-      border-radius: 12px;
-      padding: 16px;
-      display: grid;
-      place-items: center;
-    }
-
-    .mutate-thumb{
-      width: 100%;
-      max-width: 384px;
-      aspect-ratio: 1/1;
-      image-rendering: pixelated;
-      border-radius: 10px;
-      background: #0b0f1a;
-      overflow: hidden;
-      display: grid;
-      place-items: center;
-    }
-    .mutate-thumb img{ width: 100%; height: 100%; object-fit: cover; display: block; }
-
-    .mutate-actions{
-      display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-
-    /* Button look restored — neutral outline that turns green on hover */
-    .mutate-actions .btn{
-      border: 1px solid color-mix(in srgb, var(--ink, #d9e1f7) 18%, transparent);
-      background: transparent;
-      color: var(--ink, #e7ecff);
-      padding: 9px 14px;
-      border-radius: 10px;
-      cursor: pointer;
-      transition: background .15s ease, border-color .15s ease, color .15s ease, transform .02s ease;
-    }
-    .mutate-actions .btn:hover{
-      background: color-mix(in srgb, var(--accent, #22c55e) 14%, transparent);
-      border-color: color-mix(in srgb, var(--accent, #22c55e) 40%, transparent);
-    }
-    .mutate-actions .btn:active{ transform: translateY(1px); }
-
-    /* Right column (info) */
-    .mutate-info h2{
-      margin: 0 0 6px 0;
-      font-size: 20px;
-      letter-spacing: .2px;
-    }
-    .mutate-sub{
-      color: var(--muted, #97a0b2);
-      font-size: .95rem;
-      margin-bottom: 12px;
-    }
-    .mutate-list{
-      margin: 0; padding: 0 0 0 18px;
-      display: grid; gap: 6px;
-    }
-    .mutate-kv{ margin: 8px 0 0 0; color: #b8c0d6; }
-    .mutate-kv b{ color: #e6ebff; }
+    .mutate-shell{ display:grid; gap:28px; }
+    .mutate-grid{ display:grid; gap:28px; grid-template-columns:minmax(0,420px) minmax(0,1fr); align-items:start; }
+    @media (max-width:920px){ .mutate-grid{ grid-template-columns:1fr; } }
+    .mutate-preview{ display:grid; gap:18px; }
+    .mutate-card{ padding:24px; border-radius:24px; border:1px solid color-mix(in srgb,var(--border) 78%, transparent); background:linear-gradient(150deg, color-mix(in srgb,var(--panel) 85%, transparent) 0%, color-mix(in srgb,var(--panelSoft) 85%, transparent) 100%); box-shadow:0 24px 46px rgba(4,12,26,.45); display:grid; place-items:center; }
+    .mutate-thumb{ width:min(360px,100%); aspect-ratio:1/1; border-radius:18px; background:color-mix(in srgb,var(--panelSoft) 86%, transparent); border:1px solid color-mix(in srgb,var(--border) 80%, transparent); display:grid; place-items:center; overflow:hidden; }
+    .mutate-thumb img{ width:100%; height:100%; image-rendering:pixelated; object-fit:contain; }
+    .mutate-actions{ display:flex; gap:12px; flex-wrap:wrap; justify-content:center; }
+    .mutate-actions .btn{ border:1px solid color-mix(in srgb,var(--accent) 35%, transparent); background:transparent; color:var(--ink); border-radius:12px; padding:.65rem 1.05rem; font-weight:700; }
+    .mutate-actions .btn:hover{ background:color-mix(in srgb,var(--accent) 16%, transparent); }
+    .mutate-info{ display:grid; gap:18px; }
+    .mutate-info h2{ margin:0; font:800 1.6rem/1.15 var(--font-display); }
+    .mutate-sub{ margin:0; color:color-mix(in srgb,var(--muted) 78%, var(--ink) 12%); }
+    .mutate-list{ list-style:disc; margin:0; padding-left:22px; display:grid; gap:8px; }
+    .mutate-kv{ margin:0; color:color-mix(in srgb,var(--muted) 78%, var(--ink) 12%); font-size:.95rem; }
   </style>
 </head>
-<body>
-  <div id="mutateCenter">
-    <main id="mutatePage" aria-label="Mutate Frog">
-      <section class="mutate-grid">
-        <!-- LEFT: frog + buttons (buttons below the frog) -->
-        <div class="mutate-left">
-          <div class="mutate-card">
-            <div class="mutate-thumb">
-              <!-- mutate.js will replace src with the selected frog image -->
-              <img id="mutateImg" src="assets/img/placeholder-frog.png" alt="Frog preview" />
+<body class="ff-body">
+  <div class="ff-site">
+    <header class="ff-masthead">
+      <div class="ff-container ff-masthead__inner">
+        <a class="ff-logo" href="index.html"><span>🐸</span>Fresh Frogs</a>
+        <nav class="ff-nav" aria-label="Primary">
+          <a href="collection.html">Collection</a>
+          <a href="rarity.html">Rarity</a>
+          <a href="pond.html">Pond</a>
+          <a href="mutate.html" aria-current="page">Mutate</a>
+        </nav>
+        <a class="ff-button ff-button--ghost" href="collection.html">Back to dashboard</a>
+      </div>
+    </header>
+
+    <main class="ff-main">
+      <section class="ff-page-hero">
+        <div class="ff-container ff-page-hero__inner">
+          <div>
+            <span class="ff-eyebrow">Mutation lab</span>
+            <h1 class="ff-page-hero__title">Blend two frogs into a custom collectible</h1>
+            <p class="ff-page-hero__lead">
+              Select parent frogs, preview the hybrid traits, and mint a new mutation that inherits metadata directly from your
+              chosen lineup. Animation layers render exactly as they appear on-chain.
+            </p>
+            <div class="ff-page-hero__meta">
+              <span class="ff-pill">Live metadata preview</span>
+              <span class="ff-pill">Animation-aware renderer</span>
+              <span class="ff-pill">Wallet-powered minting</span>
             </div>
           </div>
-          <div class="mutate-actions">
-            <button id="btnRefresh" class="btn">Refresh</button>
-            <button id="btnMutate" class="btn">Mutate</button>
+          <div class="ff-hero__media">
+            <div class="ff-card-stack">
+              <div class="ff-card-stack__layer" data-layer="1">
+                <img data-mutate-frog="1" src="frog/512.png" alt="Frog 512" />
+                <p class="ff-card-stack__label">Fuse attributes from two parents and preview the results instantly.</p>
+              </div>
+              <div class="ff-card-stack__layer" data-layer="2">
+                <img data-mutate-frog="2" src="frog/128.png" alt="Frog 128" />
+              </div>
+              <div class="ff-card-stack__layer" data-layer="3">
+                <img data-mutate-frog="3" src="frog/45.png" alt="Frog 45" />
+              </div>
+            </div>
           </div>
         </div>
+      </section>
 
-        <!-- RIGHT: details -->
-        <div class="mutate-info">
-          <h2 id="mutateTitle">Frog #—</h2>
-          <div class="mutate-sub" id="mutateStatus">Loading…</div>
-
-          <ul class="mutate-list" id="mutateTraits">
-            <!-- populated by mutate.js -->
-          </ul>
-
-          <p class="mutate-kv" id="mutateOwner"></p>
-          <p class="mutate-kv" id="mutateNotes"></p>
+      <section class="ff-page-content">
+        <div class="ff-container">
+          <section class="ff-panel mutate-shell" aria-labelledby="mutateTitle">
+            <div class="mutate-grid">
+              <div class="mutate-preview">
+                <div class="mutate-card">
+                  <div class="mutate-thumb">
+                    <img id="mutateImg" src="assets/img/placeholder-frog.png" alt="Frog preview" />
+                  </div>
+                </div>
+                <div class="mutate-actions">
+                  <button id="btnRefresh" class="btn">Refresh</button>
+                  <button id="btnMutate" class="btn">Mutate</button>
+                </div>
+              </div>
+              <div class="mutate-info">
+                <h2 id="mutateTitle">Frog #—</h2>
+                <p class="mutate-sub" id="mutateStatus">Loading…</p>
+                <ul class="mutate-list" id="mutateTraits"></ul>
+                <p class="mutate-kv" id="mutateOwner"></p>
+                <p class="mutate-kv" id="mutateNotes"></p>
+              </div>
+            </div>
+          </section>
         </div>
       </section>
     </main>
+
+    <footer class="ff-footer">
+      <div class="ff-container ff-footer__inner">
+        <span>© Fresh Frogs</span>
+        <span>Create the next iconic hybrid.</span>
+      </div>
+    </footer>
   </div>
 
-  <!-- shared JS used across the site (order preserved) -->
+  <script>
+    (function(){
+      const CFG = window.FF_CFG || {};
+      const TOTAL = Number(CFG.TOTAL_SUPPLY || 4040);
+      const ROOT  = String(CFG.SOURCE_PATH || '').replace(/\/+$/,'');
+      function rand(n,max){
+        const pool = Array.from({length:max}, (_,i)=> i+1);
+        for(let i=pool.length-1;i>0;i--){
+          const j=Math.floor(Math.random()*(i+1));
+          const t=pool[i]; pool[i]=pool[j]; pool[j]=t;
+        }
+        return pool.slice(0,n);
+      }
+      function randomize(){
+        const imgs = Array.from(document.querySelectorAll('[data-mutate-frog]'));
+        if(!imgs.length) return;
+        const ids = rand(imgs.length, TOTAL);
+        imgs.forEach(function(img, idx){
+          const id = ids[idx];
+          img.src = ROOT + '/frog/' + id + '.png';
+          img.alt = 'Frog ' + id;
+        });
+      }
+      if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', randomize); else randomize();
+    })();
+  </script>
+
   <script src="assets/js/theme.js" defer></script>
   <script src="assets/js/topbar.js" defer></script>
   <script src="assets/js/config.js"></script>
   <script src="assets/js/utils.js" defer></script>
   <script src="assets/js/wallet.js" defer></script>
   <script src="assets/js/modal.js" defer></script>
-
-  <!-- mutate logic (drop-in below) -->
   <script src="assets/js/mutate.js" defer></script>
 </body>
 </html>

--- a/owned.html
+++ b/owned.html
@@ -1,223 +1,187 @@
 <!doctype html>
-<html lang="en" data-theme="t1">
+<html lang="en" data-theme="atlas">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>freshfrogs.github.io — My Frogs</title>
+  <title>Fresh Frogs — Sample owned view</title>
 
-  <!-- Site tokens/styles -->
   <link rel="stylesheet" href="assets/css/styles.css" />
 
   <style>
-    /* ---------- Base (same theme as main page) ---------- */
-    .pg-wrap{ padding:20px; }
-    img{ image-rendering: pixelated; image-rendering: crisp-edges; }
-
-    .pg-card{ padding:14px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
-    .pg-card-head{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
-    .pg-card-head h3{ margin:0; font-weight:800; font-size:16px; }
-    .pg-muted{ color:var(--muted); font-size:13px; }
-
-    /* ---------- Header + hero strip ---------- */
-    .topbar{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-bottom:12px; }
-    .btn{
-      font-family: var(--font-ui);
-      border:1px solid var(--border);
-      background:transparent;
-      color:inherit;
-      border-radius:8px;
-      padding:6px 10px;
-      font-weight:700;
-      font-size:12px;
-      line-height:1;
-      display:inline-flex; align-items:center; gap:6px;
-      text-decoration:none;
-      letter-spacing:.01em;
-      transition: background .15s ease, border-color .15s ease, color .15s ease, transform .05s ease;
-    }
-    .btn:active{ transform: translateY(1px); }
-    :root{ --acc-green:#22c55e; --acc-gray:#9ca3af; }
-    .btn-outline-gray{
-      border-color: color-mix(in srgb, var(--acc-gray) 70%, var(--border));
-      color: color-mix(in srgb, #ffffff 65%, var(--acc-gray));
-    }
-    .btn-outline-gray:hover{
-      background: color-mix(in srgb, var(--acc-green) 14%, var(--panel));
-      border-color: color-mix(in srgb, var(--acc-green) 80%, var(--border));
-      color: color-mix(in srgb, #ffffff 85%, var(--acc-green));
-    }
-
-    .frog-hero{ margin:24px auto 40px; }
-    .frog-title{ margin:0 0 6px 0; font:900 26px/1.15 'Space Grotesk', var(--font-ui); letter-spacing:-.01em; }
-    .frog-strip{ display:flex; gap:12px; align-items:center; overflow:hidden; padding:0; }
-    .frog-strip .tile{ flex:0 0 auto; width:64px; height:64px; border-radius:10px; overflow:hidden; border:0; background:transparent; box-shadow:none; }
-    .frog-strip .tile.hide{ display:none !important; }
-    .frog-strip img{ width:64px; height:64px; object-fit:contain; }
-    @media (max-width:520px){ .frog-hero{ margin:18px auto 32px; } .frog-strip{ gap:10px; } }
-
-    /* ---------- Owned Frogs: layout A (same as main) ---------- */
-    #ownedCard .grid-cards{ display:grid; gap:10px; grid-template-columns: 1fr; }
-    .frog-card{
-      border:1px solid var(--border);
-      background: var(--panel);
-      border-radius:14px;
-      padding:12px;
-      display:grid; grid-template-columns:auto 1fr; column-gap:12px; row-gap:6px; align-items:start;
-      color:inherit;
-    }
-    .frog-card .thumb{
-      width:128px;height:128px;border-radius:12px;background:var(--panel-2);object-fit:contain;grid-row: span 3;
-      box-shadow: inset 0 0 0 1px rgba(255,255,255,.06), 0 6px 12px rgba(0,0,0,.25);
-    }
-    .title{
-      margin:0; font-weight:900; font-size:18px; letter-spacing:-.01em;
-      display:flex; align-items:center; gap:8px;
-    }
-    .pill{
-      display:inline-block; padding:3px 10px; border-radius:999px;
-      background: color-mix(in srgb, var(--panel) 85%, transparent);
-      border:1px solid var(--border); font-size:12px;
-    }
-    .meta{ color:var(--muted); font-size:12px; }
-    .attr-list{ list-style:none; margin:6px 0 0 0; padding:0; display:flex; gap:6px; flex-wrap:wrap; }
-    .attr{ border:1px dashed var(--border); border-radius:999px; padding:4px 10px; font-size:12px; background: color-mix(in srgb, var(--panel) 85%, transparent); }
-
-    /* ---------- Button hover (same green) ---------- */
-    #ownedCard .actions{ grid-column:1 / -1; display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
-    #ownedCard .actions .btn:hover{
-      background: color-mix(in srgb, var(--acc-green) 14%, var(--panel));
-      border-color: color-mix(in srgb, var(--acc-green) 80%, var(--border));
-      color: color-mix(in srgb, #ffffff 85%, var(--acc-green));
-    }
+    .owned-grid{ display:grid; gap:22px; }
+    .owned-grid .frog-card{ position:relative; }
+    .owned-grid .actions{ display:flex; gap:10px; flex-wrap:wrap; margin-top:14px; }
   </style>
 </head>
-<body>
-  <div class="pg-wrap container">
-
-    <!-- Top nav (simple) -->
-    <div class="topbar">
-      <a class="btn btn-outline-gray" href="index.html">← Back</a>
-      <a class="btn btn-outline-gray" href="https://opensea.io/collection/freshfrogs" target="_blank" rel="noopener">OpenSea</a>
-    </div>
-
-    <!-- Page hero (keeps brand/header consistent) -->
-    <section class="frog-hero">
-      <h1 class="frog-title">My Frogs</h1>
-      <div class="frog-strip" aria-label="Showcase frogs">
-        <!-- A few tiles; script keeps only whole tiles visible -->
-        <div class="tile"><img src="frog/12.png"  alt="12"></div>
-        <div class="tile"><img src="frog/77.png"  alt="77"></div>
-        <div class="tile"><img src="frog/404.png" alt="404"></div>
-        <div class="tile"><img src="frog/256.png" alt="256"></div>
-        <div class="tile"><img src="frog/999.png" alt="999"></div>
-        <div class="tile"><img src="frog/1.png"   alt="1"></div>
+<body class="ff-body">
+  <div class="ff-site">
+    <header class="ff-masthead">
+      <div class="ff-container ff-masthead__inner">
+        <a class="ff-logo" href="index.html"><span>🐸</span>Fresh Frogs</a>
+        <nav class="ff-nav" aria-label="Primary">
+          <a href="collection.html">Collection</a>
+          <a href="rarity.html">Rarity</a>
+          <a href="pond.html">Pond</a>
+          <a href="mutate.html">Mutate</a>
+        </nav>
+        <a class="ff-button ff-button--ghost" href="collection.html">Back to dashboard</a>
       </div>
-    </section>
+    </header>
 
-    <!-- Owned: Layout A -->
-    <section id="ownedCard" class="pg-card">
-      <div class="pg-card-head">
-        <h3>My Frogs (Owned)</h3>
+    <main class="ff-main">
+      <section class="ff-page-hero">
+        <div class="ff-container ff-page-hero__inner">
+          <div>
+            <span class="ff-eyebrow">Sample layout</span>
+            <h1 class="ff-page-hero__title">Owned frogs showcase</h1>
+            <p class="ff-page-hero__lead">
+              This static page previews how frog cards render within the refreshed layout. Connect on the collection dashboard to
+              see your live inventory, staking status, and actions.
+            </p>
+            <div class="ff-page-hero__meta">
+              <span class="ff-pill">Live rarity pill support</span>
+              <span class="ff-pill">Actions underneath cards</span>
+              <span class="ff-pill">Metadata-aligned attributes</span>
+            </div>
+          </div>
+          <div class="ff-hero__media">
+            <div class="ff-card-stack">
+              <div class="ff-card-stack__layer" data-layer="1">
+                <img data-owned-frog="1" src="frog/18.png" alt="Frog 18" />
+                <p class="ff-card-stack__label">Card styling mirrors the interactive dashboard.</p>
+              </div>
+              <div class="ff-card-stack__layer" data-layer="2">
+                <img data-owned-frog="2" src="frog/73.png" alt="Frog 73" />
+              </div>
+              <div class="ff-card-stack__layer" data-layer="3">
+                <img data-owned-frog="3" src="frog/404.png" alt="Frog 404" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="ff-page-content">
+        <div class="ff-container">
+          <section class="ff-panel" aria-labelledby="ownedHeading">
+            <div class="ff-toolbar" style="margin-bottom:12px;">
+              <h2 id="ownedHeading" style="margin:0;">Example frogs</h2>
+              <p class="muted" style="margin:0; max-width:40ch;">Static examples show how owned frogs appear with rarity pills and action buttons.</p>
+            </div>
+            <div id="ownedGrid" class="owned-grid frog-cards">
+              <article class="frog-card" data-token-id="12">
+                <div class="row">
+                  <div class="thumb-wrap"><img class="thumb" src="frog/12.png" alt="Frog 12"></div>
+                  <div>
+                    <h3 class="title">Frog #12 <span class="pill" data-rank>Rank —</span></h3>
+                    <p class="meta">Owned by You</p>
+                    <ul class="attr-bullets">
+                      <li>Background: <b>Blue</b></li>
+                      <li>Eyes: <b>Laser</b></li>
+                      <li>Mouth: <b>Smile</b></li>
+                      <li>Accessory: <b>Lily</b></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="actions">
+                  <a class="ff-button ff-button--ghost btn" href="https://opensea.io/assets/ethereum/0xYOUR_COLLECTION_ADDRESS/12" target="_blank" rel="noopener">OpenSea</a>
+                  <a class="ff-button ff-button--ghost btn" href="https://etherscan.io/token/0xYOUR_COLLECTION_ADDRESS?a=12" target="_blank" rel="noopener">Etherscan</a>
+                  <a class="ff-button ff-button--ghost btn" href="frog/12.png" target="_blank" rel="noopener">Original</a>
+                </div>
+              </article>
+
+              <article class="frog-card" data-token-id="77">
+                <div class="row">
+                  <div class="thumb-wrap"><img class="thumb" src="frog/77.png" alt="Frog 77"></div>
+                  <div>
+                    <h3 class="title">Frog #77 <span class="pill" data-rank>Rank —</span></h3>
+                    <p class="meta"><span class="staked-flag">Staked 1123d ago by You</span></p>
+                    <ul class="attr-bullets">
+                      <li>Background: <b>Green</b></li>
+                      <li>Eyes: <b>Wide</b></li>
+                      <li>Mouth: <b>Neutral</b></li>
+                      <li>Accessory: <b>Scarf</b></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="actions">
+                  <a class="ff-button ff-button--ghost btn" href="https://opensea.io/assets/ethereum/0xYOUR_COLLECTION_ADDRESS/77" target="_blank" rel="noopener">OpenSea</a>
+                  <a class="ff-button ff-button--ghost btn" href="https://etherscan.io/token/0xYOUR_COLLECTION_ADDRESS?a=77" target="_blank" rel="noopener">Etherscan</a>
+                  <a class="ff-button ff-button--ghost btn" href="frog/77.png" target="_blank" rel="noopener">Original</a>
+                </div>
+              </article>
+
+              <article class="frog-card" data-token-id="404">
+                <div class="row">
+                  <div class="thumb-wrap"><img class="thumb" src="frog/404.png" alt="Frog 404"></div>
+                  <div>
+                    <h3 class="title">Frog #404 <span class="pill" data-rank>Rank —</span></h3>
+                    <p class="meta">Owned by You</p>
+                    <ul class="attr-bullets">
+                      <li>Background: <b>Charcoal</b></li>
+                      <li>Eyes: <b>Sleepy</b></li>
+                      <li>Mouth: <b>Frown</b></li>
+                      <li>Accessory: <b>Lily</b></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="actions">
+                  <a class="ff-button ff-button--ghost btn" href="https://opensea.io/assets/ethereum/0xYOUR_COLLECTION_ADDRESS/404" target="_blank" rel="noopener">OpenSea</a>
+                  <a class="ff-button ff-button--ghost btn" href="https://etherscan.io/token/0xYOUR_COLLECTION_ADDRESS?a=404" target="_blank" rel="noopener">Etherscan</a>
+                  <a class="ff-button ff-button--ghost btn" href="frog/404.png" target="_blank" rel="noopener">Original</a>
+                </div>
+              </article>
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="ff-footer">
+      <div class="ff-container ff-footer__inner">
+        <span>© Fresh Frogs</span>
+        <span>Preview the refreshed card styling.</span>
       </div>
-
-      <div class="grid-cards" id="ownedGrid">
-        <!-- Sample cards (replace with dynamic render if desired) -->
-        <article class="frog-card" data-token-id="12">
-          <img class="thumb" src="frog/12.png" alt="12">
-          <h4 class="title">Frog #12 <span class="pill" data-rank>Rank —</span></h4>
-          <div class="meta">Not staked • Owned by You</div>
-          <ul class="attr-list" aria-label="Attributes">
-            <li class="attr">Background: <b>Blue</b></li>
-            <li class="attr">Eyes: <b>Laser</b></li>
-            <li class="attr">Mouth: <b>Smile</b></li>
-            <li class="attr">Hat: <b>Cap</b></li>
-          </ul>
-          <div class="actions">
-            <button class="btn btn-outline-gray">Stake</button>
-            <button class="btn btn-outline-gray">Transfer</button>
-            <a class="btn btn-outline-gray" href="https://opensea.io/assets/ethereum/0xYOUR_COLLECTION_ADDRESS/12" target="_blank" rel="noopener">OpenSea</a>
-            <a class="btn btn-outline-gray" href="https://etherscan.io/token/0xYOUR_COLLECTION_ADDRESS?a=12" target="_blank" rel="noopener">Etherscan</a>
-            <a class="btn btn-outline-gray" href="frog/12.png" target="_blank" rel="noopener">Original</a>
-          </div>
-        </article>
-
-        <article class="frog-card" data-token-id="77">
-          <img class="thumb" src="frog/77.png" alt="77">
-          <h4 class="title">Frog #77 <span class="pill" data-rank>Rank —</span></h4>
-          <div class="meta">Staked 1123d ago • Owned by You</div>
-          <ul class="attr-list" aria-label="Attributes">
-            <li class="attr">Background: <b>Green</b></li>
-            <li class="attr">Eyes: <b>Wide</b></li>
-            <li class="attr">Mouth: <b>Neutral</b></li>
-            <li class="attr">Accessory: <b>Scarf</b></li>
-          </ul>
-          <div class="actions">
-            <button class="btn btn-outline-gray">Unstake</button>
-            <button class="btn btn-outline-gray">Transfer</button>
-            <a class="btn btn-outline-gray" href="https://opensea.io/assets/ethereum/0xYOUR_COLLECTION_ADDRESS/77" target="_blank" rel="noopener">OpenSea</a>
-            <a class="btn btn-outline-gray" href="https://etherscan.io/token/0xYOUR_COLLECTION_ADDRESS?a=77" target="_blank" rel="noopener">Etherscan</a>
-            <a class="btn btn-outline-gray" href="frog/77.png" target="_blank" rel="noopener">Original</a>
-          </div>
-        </article>
-
-        <article class="frog-card" data-token-id="404">
-          <img class="thumb" src="frog/404.png" alt="404">
-          <h4 class="title">Frog #404 <span class="pill" data-rank>Rank —</span></h4>
-          <div class="meta">Not staked • Owned by You</div>
-          <ul class="attr-list" aria-label="Attributes">
-            <li class="attr">Background: <b>Charcoal</b></li>
-            <li class="attr">Eyes: <b>Sleepy</b></li>
-            <li class="attr">Mouth: <b>Frown</b></li>
-            <li class="attr">Item: <b>Lily</b></li>
-          </ul>
-          <div class="actions">
-            <button class="btn btn-outline-gray">Stake</button>
-            <button class="btn btn-outline-gray">Transfer</button>
-            <a class="btn btn-outline-gray" href="https://opensea.io/assets/ethereum/0xYOUR_COLLECTION_ADDRESS/404" target="_blank" rel="noopener">OpenSea</a>
-            <a class="btn btn-outline-gray" href="https://etherscan.io/token/0xYOUR_COLLECTION_ADDRESS?a=404" target="_blank" rel="noopener">Etherscan</a>
-            <a class="btn btn-outline-gray" href="frog/404.png" target="_blank" rel="noopener">Original</a>
-          </div>
-        </article>
-      </div>
-    </section>
-
+    </footer>
   </div>
 
   <script>
-    /* --- Frog strip: keep whole 64px tiles only (same behavior as main page) --- */
-    function layoutFrogStrip(){
-      var strip = document.querySelector('.frog-strip');
-      if(!strip) return;
-      var tiles = Array.prototype.slice.call(strip.querySelectorAll('.tile'));
-      var styles = window.getComputedStyle(strip);
-      var gap = parseFloat(styles.gap || 12) || 12;
-      var tileW = 64;
-      var innerW = strip.clientWidth;
-      var count = Math.max(1, Math.floor((innerW + gap) / (tileW + gap)));
-      tiles.forEach(function(t,i){ t.classList.toggle('hide', i >= count); });
-    }
-    window.addEventListener('resize', layoutFrogStrip);
-    document.addEventListener('DOMContentLoaded', layoutFrogStrip);
-
-    /* --- Rarity rank pills: hydrate from JSON (same file used on main) --- */
     (function(){
-      var URL = 'freshfrogs_rarity_rankings.json';
-      async function loadRanks(){
-        try{
-          var res = await fetch(URL, { cache:'force-cache' });
-          if(!res.ok) throw new Error('HTTP '+res.status);
-          var arr = await res.json();
-          var map = new Map(arr.map(function(o){ return [String(o.id), o.ranking]; }));
-          document.querySelectorAll('#ownedGrid .frog-card').forEach(function(card){
-            var id = String(card.getAttribute('data-token-id')||'').trim();
-            var pill = card.querySelector('[data-rank]');
-            if(!id || !pill) return;
-            var r = map.get(id);
-            pill.textContent = r ? ('Rank #'+r) : 'Rank N/A';
-          });
-        }catch(e){ console.warn('[ranks] failed', e); }
+      const CFG = window.FF_CFG || {};
+      const TOTAL = Number(CFG.TOTAL_SUPPLY || 4040);
+      const ROOT  = String(CFG.SOURCE_PATH || '').replace(/\/+$/,'');
+      function rand(n,max){
+        const pool = Array.from({length:max}, (_,i)=> i+1);
+        for(let i=pool.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); const t=pool[i]; pool[i]=pool[j]; pool[j]=t; }
+        return pool.slice(0,n);
       }
-      if(document.readyState === 'loading') document.addEventListener('DOMContentLoaded', loadRanks); else loadRanks();
+      function randomize(){
+        const imgs = Array.from(document.querySelectorAll('[data-owned-frog]'));
+        if(!imgs.length) return;
+        const ids = rand(imgs.length, TOTAL);
+        imgs.forEach(function(img, idx){
+          const id = ids[idx];
+          img.src = ROOT + '/frog/' + id + '.png';
+          img.alt = 'Frog ' + id;
+        });
+      }
+      function hydrateRanks(){
+        fetch('freshfrogs_rarity_rankings.json').then(function(res){ return res.ok ? res.json() : []; }).then(function(rows){
+          if(!Array.isArray(rows)) return;
+          const map = new Map(rows.map(function(r){ return [String(r.id), r.ranking]; }));
+          document.querySelectorAll('#ownedGrid [data-rank]').forEach(function(pill){
+            const card = pill.closest('[data-token-id]');
+            const id = card ? String(card.getAttribute('data-token-id')) : '';
+            const rank = id ? map.get(id) : null;
+            pill.textContent = rank ? 'Rank #' + rank : 'Rank —';
+          });
+        }).catch(function(){});
+      }
+      if(document.readyState==='loading'){
+        document.addEventListener('DOMContentLoaded', function(){ randomize(); hydrateRanks(); });
+      }else{
+        randomize(); hydrateRanks();
+      }
     })();
   </script>
 </body>

--- a/pond.html
+++ b/pond.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en" data-theme="atlas" data-card-layout="classic">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Staking pond</title>
+
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="ff-body">
+  <div class="ff-site">
+    <header class="ff-masthead">
+      <div class="ff-container ff-masthead__inner">
+        <a class="ff-logo" href="index.html"><span>🐸</span>Fresh Frogs</a>
+        <nav class="ff-nav" aria-label="Primary">
+          <a href="collection.html">Collection</a>
+          <a href="rarity.html">Rarity</a>
+          <a href="pond.html" aria-current="page">Pond</a>
+          <a href="mutate.html">Mutate</a>
+        </nav>
+        <a class="ff-button ff-button--ghost" href="collection.html">Manage frogs</a>
+      </div>
+    </header>
+
+    <main class="ff-main">
+      <section class="ff-page-hero">
+        <div class="ff-container ff-page-hero__inner">
+          <div>
+            <span class="ff-eyebrow">Staking overview</span>
+            <h1 class="ff-page-hero__title">Every frog currently relaxing in the pond</h1>
+            <p class="ff-page-hero__lead">
+              Filter the roster of staked frogs, sort by rarity rank or staking duration, and inspect layered artwork without
+              leaving the dashboard.
+            </p>
+            <div class="ff-page-hero__meta">
+              <span class="ff-pill">Live staking feed</span>
+              <span class="ff-pill">Controller-powered ownership</span>
+              <span class="ff-pill">Metadata-true layering</span>
+            </div>
+          </div>
+          <div class="ff-hero__media">
+            <div class="ff-card-stack">
+              <div class="ff-card-stack__layer" data-layer="1">
+                <img data-pond-frog="1" src="frog/210.png" alt="Frog 210" />
+                <p class="ff-card-stack__label">Track staking age with animated progress bars and accurate owner labels.</p>
+              </div>
+              <div class="ff-card-stack__layer" data-layer="2">
+                <img data-pond-frog="2" src="frog/415.png" alt="Frog 415" />
+              </div>
+              <div class="ff-card-stack__layer" data-layer="3">
+                <img data-pond-frog="3" src="frog/37.png" alt="Frog 37" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="ff-container" id="ffTopbarMount"></div>
+
+      <section class="ff-page-content">
+        <div class="ff-container">
+          <section class="ff-panel" aria-labelledby="pondControls">
+            <div class="ff-toolbar">
+              <div class="ff-toolbar__group">
+                <h2 id="pondControls" style="margin:0;">Currently staked frogs</h2>
+                <p class="muted" style="margin:0; max-width:36ch;">Sort the roster and jump directly to any frog ID to view its staking details.</p>
+              </div>
+              <div class="ff-toolbar__group">
+                <button id="btnSortRank" class="ff-button">Sort: Rank ↑</button>
+                <button id="btnSortScore" class="ff-button">Sort: Time ↑</button>
+              </div>
+            </div>
+
+            <div class="ff-toolbar" style="margin-top:18px;">
+              <div class="ff-toolbar__group">
+                <label class="sr-only" for="raritySearchId">Find frog ID</label>
+                <input id="raritySearchId" class="ff-input" type="number" min="1" placeholder="Find frog ID…" />
+                <button id="btnGo" class="ff-button ff-button--solid">Go</button>
+              </div>
+            </div>
+
+            <div id="rarityGrid" class="ff-grid-cards">
+              <div class="pg-muted">Loading staked frogs…</div>
+            </div>
+
+            <div class="ff-toolbar" style="justify-content:center; margin-top:28px;">
+              <button id="btnMore" class="ff-button ff-button--ghost" style="display:none;">Load more</button>
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="ff-footer">
+      <div class="ff-container ff-footer__inner">
+        <span>© Fresh Frogs</span>
+        <span>Keep an eye on the staking pond.</span>
+      </div>
+    </footer>
+  </div>
+
+  <script>
+    (function(){
+      const CFG = window.FF_CFG || {};
+      const TOTAL = Number(CFG.TOTAL_SUPPLY || 4040);
+      const ROOT  = String(CFG.SOURCE_PATH || '').replace(/\/+$/,'');
+      function shuffle(n,max){
+        const pool = Array.from({length:max}, (_,i)=> i+1);
+        for(let i=pool.length-1;i>0;i--){
+          const j=Math.floor(Math.random()*(i+1));
+          const t=pool[i]; pool[i]=pool[j]; pool[j]=t;
+        }
+        return pool.slice(0,n);
+      }
+      function randomize(){
+        const imgs = Array.from(document.querySelectorAll('[data-pond-frog]'));
+        if(!imgs.length) return;
+        const ids = shuffle(imgs.length, TOTAL);
+        imgs.forEach(function(img, idx){
+          const id = ids[idx];
+          img.src = ROOT + '/frog/' + id + '.png';
+          img.alt = 'Frog ' + id;
+        });
+      }
+      if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', randomize); else randomize();
+    })();
+  </script>
+
+  <script src="https://cdn.jsdelivr.net/npm/web3@1.10.4/dist/web3.min.js"></script>
+  <script src="assets/js/config.js"></script>
+  <script src="assets/js/utils.js"></script>
+  <script src="assets/js/rarity.js"></script>
+  <script src="assets/js/modal.js"></script>
+  <script src="assets/abi/collection_abi.js"></script>
+  <script src="assets/abi/controller_abi.js"></script>
+  <script src="assets/js/staking-adapter.js"></script>
+  <script src="assets/js/frog-renderer.js"></script>
+  <script src="assets/js/frog-cards.js" defer></script>
+  <script src="assets/js/topbar.js"></script>
+  <script>
+    window.FF_RARITY_PAGE_CONFIG = {
+      stakedOnly: true,
+      defaultSortMode: 'rank',
+      secondSortMode: 'time',
+      autoLoadMin: 9
+    };
+  </script>
+  <script src="assets/js/rarity-page.js"></script>
+</body>
+</html>

--- a/rarity.html
+++ b/rarity.html
@@ -1,155 +1,168 @@
 <!doctype html>
-<html lang="en" data-theme="t1">
+<html lang="en" data-theme="atlas">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>freshfrogs — Rarity</title>
+  <title>Fresh Frogs — Rarity explorer</title>
 
   <link rel="stylesheet" href="assets/css/styles.css" />
-
-  <style>
-    /* mirror collection.html base feel */
-    .pg-wrap{ padding:20px; }
-    img{ image-rendering: pixelated; image-rendering: crisp-edges; }
-
-    .pg-card{ padding:14px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
-    .pg-card-head{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
-    .pg-card-head h3{ margin:0; font-weight:800; font-size:16px; }
-    .pg-muted{ color:var(--muted); font-size:13px; }
-
-    /* Hero (identical structure so topbar.js pills work) */
-    .frog-hero{ margin:28px auto 38px; max-width:1100px; }
-    .frog-title{ margin:0 0 6px 0; font:900 28px/1.15 'Space Grotesk', var(--font-ui); letter-spacing:-.01em; text-align:center; }
-    .frog-strip{ display:flex; gap:12px; align-items:center; justify-content:center; overflow:hidden; padding:0; }
-    .frog-strip .tile{ flex:0 0 auto; width:64px; height:64px; border-radius:10px; }
-    .frog-strip .tile.hide{ display:none !important; }
-    .frog-strip img{ width:64px; height:64px; object-fit:contain; }
-    @media (max-width:520px){ .frog-hero{ margin:22px auto 30px; } .frog-strip{ gap:10px; } }
-
-    /* Single main panel with the grid */
-    .page-grid{ max-width:1100px; margin:0 auto; display:grid; gap:16px; grid-template-columns: 1fr; }
-
-    /* Use the same card styles defined in collection.html */
-    .frog-card{ border:1px solid var(--border); background:var(--panel); border-radius:14px; padding:12px;
-      display:grid; grid-template-columns:auto 1fr; column-gap:12px; row-gap:6px; align-items:start; color:inherit; }
-    .frog-card .thumb{
-      width:128px;height:128px;border-radius:12px;background:var(--panel-2);object-fit:contain;grid-row: span 3;
-      box-shadow: inset 0 0 0 1px rgba(255,255,255,.06), 0 6px 12px rgba(0,0,0,.25);
-    }
-    .title{ margin:0; font-weight:900; font-size:18px; letter-spacing:-.01em; display:flex; align-items:center; gap:8px; }
-    .pill{ display:inline-block; padding:3px 10px; border-radius:999px; background: color-mix(in srgb, var(--panel) 85%, transparent); border:1px solid var(--border); font-size:12px; }
-    .meta{ color:var(--muted); font-size:12px; }
-    .actions{ grid-column:1 / -1; display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
-    .btn{
-      font-family: var(--font-ui);
-      border:1px solid var(--border);
-      background:transparent;
-      color:inherit;
-      border-radius:8px;
-      padding:6px 10px;
-      font-weight:700;
-      font-size:12px;
-      line-height:1;
-      display:inline-flex; align-items:center; gap:6px;
-      text-decoration:none; letter-spacing:.01em;
-      transition: background .15s ease, border-color .15s ease, color .15s ease, transform .05s ease;
-    }
-    .btn:active{ transform: translateY(1px); }
-    .btn-outline-gray{ border-color: color-mix(in srgb, #9ca3af 70%, var(--border)); color: color-mix(in srgb, #ffffff 65%, #9ca3af); }
-    .btn:hover{
-      background: color-mix(in srgb, #22c55e 14%, var(--panel));
-      border-color: color-mix(in srgb, #22c55e 80%, var(--border));
-      color: color-mix(in srgb, #ffffff 85%, #22c55e);
-    }
-
-    /* Grid */
-    #rarityGrid{ display:grid; gap:10px; grid-template-columns: 1fr; }
-    @media (min-width:720px){ #rarityGrid{ grid-template-columns: 1fr 1fr; } }
-    @media (min-width:1024px){ #rarityGrid{ grid-template-columns: 1fr 1fr 1fr; } }
-
-    /* Rank badge for image (optional; your card renderer can also inject this) */
-    .rank-badge{
-      position:absolute; top:8px; left:8px;
-      background:var(--ink,#0c0c0f); color:var(--fg,#eaeaea);
-      border:1px solid var(--border,#2a2a2f); border-radius:999px; padding:4px 10px; font-size:12px;
-      letter-spacing:.2px; opacity:.96;
-    }
-    .img-wrap{ position:relative; }
-  </style>
 </head>
-<body>
-  <div class="pg-wrap container">
-    <!-- HERO (keep identical so topbar pills render) -->
-    <section class="frog-hero">
-      <h1 class="frog-title">freshfrogs.github.io</h1>
-      <div class="frog-strip">
-        <div class="tile"><img src="frog/12.png"  alt="12"></div>
-        <div class="tile"><img src="frog/77.png"  alt="77"></div>
-        <div class="tile"><img src="frog/404.png" alt="404"></div>
-        <div class="tile"><img src="frog/256.png" alt="256"></div>
-        <div class="tile"><img src="frog/999.png" alt="999"></div>
-        <div class="tile"><img src="frog/1.png"   alt="1"></div>
+<body class="ff-body">
+  <div class="ff-site">
+    <header class="ff-masthead">
+      <div class="ff-container ff-masthead__inner">
+        <a class="ff-logo" href="index.html"><span>🐸</span>Fresh Frogs</a>
+        <nav class="ff-nav" aria-label="Primary">
+          <a href="collection.html">Collection</a>
+          <a href="rarity.html" aria-current="page">Rarity</a>
+          <a href="pond.html">Pond</a>
+          <a href="mutate.html">Mutate</a>
+        </nav>
+        <a class="ff-button ff-button--ghost" href="pond.html">View pond</a>
       </div>
-    </section>
-    <div id="ffTopbarMount"></div>
+    </header>
 
-    <div class="page-grid">
-      <section class="pg-card">
-        <div class="pg-card-head">
-          <h3>Rarity Rankings</h3>
-          <div style="display:flex;gap:8px;flex-wrap:wrap;">
-            <button id="btnSortRank"  class="btn btn-outline-gray">Sort: Rank ↑</button>
-            <button id="btnSortScore" class="btn btn-outline-gray">Sort: Score ↓</button>
-            <input id="raritySearchId" type="number" min="1" placeholder="Find Frog ID…" style="width:140px; padding:6px 10px; border:1px solid var(--border); border-radius:8px; background:var(--panel-2); color:inherit;">
-            <button id="btnGo" class="btn btn-outline-gray">Go</button>
+    <main class="ff-main">
+      <section class="ff-page-hero">
+        <div class="ff-container ff-page-hero__inner">
+          <div>
+            <span class="ff-eyebrow">Rarity explorer</span>
+            <h1 class="ff-page-hero__title">Discover legendary frogs and hidden traits</h1>
+            <p class="ff-page-hero__lead">
+              Filter, sort, and search the entire Fresh Frogs collection. Every card includes live owner data, staking status,
+              and layered artwork rendered directly from the metadata order.
+            </p>
+            <div class="ff-page-hero__meta">
+              <span class="ff-pill">Live rarity updates</span>
+              <span class="ff-pill">Accurate staking info</span>
+              <span class="ff-pill">10 visual themes</span>
+            </div>
+          </div>
+          <div class="ff-hero__media">
+            <div class="ff-card-stack">
+              <div class="ff-card-stack__layer" data-layer="1">
+                <img data-rarity-frog="1" src="frog/88.png" alt="Frog 88" />
+                <p class="ff-card-stack__label">Flip between rarity themes to preview foil-inspired card treatments.</p>
+              </div>
+              <div class="ff-card-stack__layer" data-layer="2">
+                <img data-rarity-frog="2" src="frog/144.png" alt="Frog 144" />
+              </div>
+              <div class="ff-card-stack__layer" data-layer="3">
+                <img data-rarity-frog="3" src="frog/321.png" alt="Frog 321" />
+              </div>
+            </div>
           </div>
         </div>
+      </section>
 
-        <div id="rarityGrid">
-          <div class="pg-muted">Loading rarity…</div>
-        </div>
+      <div class="ff-container" id="ffTopbarMount"></div>
 
-        <div style="display:grid; place-items:center; margin-top:10px;">
-          <button id="btnMore" class="btn btn-outline-gray" style="display:none;">Load More</button>
+      <section class="ff-page-content">
+        <div class="ff-container">
+          <div class="ff-page-grid">
+            <section class="ff-panel" aria-labelledby="rarityControlsTitle">
+              <div class="ff-toolbar">
+                <div class="ff-toolbar__group">
+                  <h2 id="rarityControlsTitle" style="margin:0;">Rarity rankings</h2>
+                  <p class="muted" style="margin:0; max-width:36ch;">Sort by rank, rarity score, or staking time, then deep dive into each layered frog card.</p>
+                </div>
+                <button id="btnThemeCycle" class="ff-button ff-button--ghost">Theme sampler</button>
+              </div>
+
+              <div class="ff-toolbar" style="margin-top:18px;">
+                <div class="ff-toolbar__group">
+                  <button id="btnSortRank" class="ff-button">Sort: Rank ↑</button>
+                  <button id="btnSortScore" class="ff-button">Sort: Score ↓</button>
+                </div>
+                <div class="ff-toolbar__group">
+                  <label class="sr-only" for="raritySearchId">Jump to frog ID</label>
+                  <input id="raritySearchId" class="ff-input" type="number" min="1" placeholder="Find frog ID…" />
+                  <button id="btnGo" class="ff-button ff-button--solid">Go</button>
+                </div>
+              </div>
+
+              <div id="rarityGrid" class="ff-grid-cards">
+                <div class="pg-muted">Loading rarity…</div>
+              </div>
+
+              <div class="ff-toolbar" style="justify-content:center; margin-top:28px;">
+                <button id="btnMore" class="ff-button ff-button--ghost" style="display:none;">Load more frogs</button>
+              </div>
+            </section>
+
+            <aside class="ff-side-panel">
+              <section class="ff-panel" aria-labelledby="rarityTips">
+                <div>
+                  <h2 id="rarityTips">Tips for explorers</h2>
+                  <p class="muted">Keep these shortcuts in mind while browsing the rankings.</p>
+                </div>
+                <ul class="ff-list-compact">
+                  <li>
+                    <strong>Theme sampler</strong>
+                    <span class="meta">Cycle through ten foil-inspired treatments for the card layout.</span>
+                  </li>
+                  <li>
+                    <strong>Staking indicators</strong>
+                    <span class="meta">Cards highlight staking age and owner data pulled from the controller.</span>
+                  </li>
+                  <li>
+                    <strong>Metadata order</strong>
+                    <span class="meta">Traits render in the exact order stored in <code>frog/json/&lt;id&gt;.json</code>.</span>
+                  </li>
+                </ul>
+              </section>
+            </aside>
+          </div>
         </div>
       </section>
-    </div>
+    </main>
+
+    <footer class="ff-footer">
+      <div class="ff-container ff-footer__inner">
+        <span>© Fresh Frogs</span>
+        <span>Analyze rarity and stake smarter.</span>
+      </div>
+    </footer>
   </div>
 
   <script>
-    /* keep hero strip behavior the same */
-    function layoutFrogStrip(){
-      var strip = document.querySelector('.frog-strip'); if(!strip) return;
-      var tiles = Array.prototype.slice.call(strip.querySelectorAll('.tile'));
-      var styles = window.getComputedStyle(strip);
-      var gap = parseFloat(styles.gap || 12) || 12;
-      var tileW = 64, innerW = strip.clientWidth;
-      var count = Math.max(1, Math.floor((innerW + gap) / (tileW + gap)));
-      tiles.forEach(function(t,i){ t.classList.toggle('hide', i >= count); });
-    }
-    window.addEventListener('resize', layoutFrogStrip);
-    document.addEventListener('DOMContentLoaded', layoutFrogStrip);
+    (function(){
+      const CFG = window.FF_CFG || {};
+      const TOTAL = Number(CFG.TOTAL_SUPPLY || 4040);
+      const ROOT  = String(CFG.SOURCE_PATH || '').replace(/\/+$/,'');
+      function sample(n,max){
+        const pool = Array.from({length:max}, (_,i)=> i+1);
+        for(let i=pool.length-1;i>0;i--){
+          const j=Math.floor(Math.random()*(i+1));
+          const t=pool[i]; pool[i]=pool[j]; pool[j]=t;
+        }
+        return pool.slice(0,n);
+      }
+      function randomize(){
+        const imgs = Array.from(document.querySelectorAll('[data-rarity-frog]'));
+        if(!imgs.length) return;
+        const ids = sample(imgs.length, TOTAL);
+        imgs.forEach(function(img, idx){
+          const id = ids[idx];
+          img.src = ROOT + '/frog/' + id + '.png';
+          img.alt = 'Frog ' + id;
+        });
+      }
+      if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', randomize); else randomize();
+    })();
   </script>
 
-  <!-- match your collection.html script stack/order (only what we need here) -->
   <script src="https://cdn.jsdelivr.net/npm/web3@1.10.4/dist/web3.min.js"></script>
   <script src="assets/js/config.js"></script>
   <script src="assets/js/utils.js"></script>
   <script src="assets/js/rarity.js"></script>
   <script src="assets/js/modal.js"></script>
-
-  <!-- ABIs (some renderers or links reference addresses) -->
   <script src="assets/abi/collection_abi.js"></script>
   <script src="assets/abi/controller_abi.js"></script>
-
-  <!-- Card + renderer (same as dashboard) -->
+  <script src="assets/js/staking-adapter.js"></script>
   <script src="assets/js/frog-renderer.js"></script>
   <script src="assets/js/frog-cards.js" defer></script>
-
-  <!-- Top bar pills -->
   <script src="assets/js/topbar.js"></script>
-
-  <!-- Rarity page glue -->
   <script src="assets/js/rarity-page.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the legacy landing page with a new navigation header, hero stack, feature panels, and refreshed mint/activity sections
- restyle the collection, rarity, pond, mutate, and owned experiences to share the new shell, hero treatments, and panel layout
- update shared scripts and card styling so the owned panel, top bar, and frog cards align with the refreshed markup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db79b842988331a0be89ddd6adef49