### PR TITLE
Restore classic layout and add layout prototypes

### DIFF
--- a/assets/js/frog-cards.js
+++ b/assets/js/frog-cards.js
@@ -8,40 +8,191 @@
   const CFG = window.FF_CFG || {};
   const CHAIN_ID = Number(CFG.CHAIN_ID || 1);
   const BASEPATH = (CFG.SOURCE_PATH || '').replace(/\/+$/,'');
-  const LEVEL_SECS = Math.max(1, Number(CFG.STAKE_LEVEL_SECONDS || 86400));
+  const LEVEL_SECS = Math.max(1, Number(CFG.STAKE_LEVEL_SECONDS || (30 * 86400)));
   const NO_HOVER_KEYS = new Set(['Trait','Frog','SpecialFrog']);
+  const CARD_LAYOUTS = ['classic'];
+  const CARD_LAYOUT_LABELS = {
+    classic: 'Classic'
+  };
 
   (function injectCSS(){
     if (document.getElementById('ff-frog-cards-css')) return;
     const css = `
-.frog-cards{ display:grid; gap:10px; }
-.frog-card{ padding:14px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
-.frog-card .row{ display:grid; grid-template-columns:auto 1fr; gap:12px; align-items:start; }
-.frog-card .thumb-wrap{ width:128px; min-width:128px; position:relative; } /* relative for GIF overlays */
-.frog-card .thumb, .frog-card canvas.frog-canvas{
-  width:128px; height:128px; min-width:128px; min-height:128px;
-  border-radius:10px; object-fit:contain; background:var(--panel-2); display:block;
+.frog-cards{ display:grid; gap:26px; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); }
+.frog-card{
+  position:relative;
+  padding:24px 22px 22px;
+  border-radius:22px;
+  background:color-mix(in srgb, var(--card-inner) 84%, var(--card));
+  border:1px solid color-mix(in srgb, var(--card-frame) 45%, transparent);
+  box-shadow:var(--card-shadow, 0 24px 50px rgba(0,0,0,.4));
+  overflow:hidden;
+  color:var(--ink);
+  --fc-muted: color-mix(in srgb, var(--muted) 70%, #ffffff 10%);
 }
-.frog-card .title{ margin:0 0 4px 0; font-weight:800; font-size:16px; }
-.frog-card .pill{ font-size:12px; padding:2px 8px; border:1px solid var(--border); border-radius:999px; vertical-align:middle; }
-.frog-card .pill.rk-legendary{ color:#f59e0b; border-color: color-mix(in srgb,#f59e0b 70%, var(--border)); }
-.frog-card .pill.rk-epic{ color:#a855f7; border-color: color-mix(in srgb,#a855f7 70%, var(--border)); }
-.frog-card .pill.rk-rare{ color:#38bdf8; border-color: color-mix(in srgb,#38bdf8 70%, var(--border)); }
-.frog-card .meta{ margin:0; color:#22c55e; } /* staked line in green */
-.frog-card .attr-bullets{ list-style:disc; margin:6px 0 0 18px; padding:0; }
-.frog-card .attr-bullets li{ font-size:12px; margin:2px 0; cursor:default; }
+.frog-card::before{
+  content:'';
+  position:absolute;
+  inset:0;
+  background:var(--card-foil, linear-gradient(135deg, rgba(255,255,255,.08), transparent 70%));
+  mix-blend-mode:screen;
+  opacity:.5;
+  pointer-events:none;
+}
+.frog-card::after{
+  content:'';
+  position:absolute;
+  inset:1px;
+  border-radius:20px;
+  background:color-mix(in srgb, var(--panelSoft) 78%, transparent);
+  opacity:.85;
+  pointer-events:none;
+}
+.frog-card .row{
+  position:relative;
+  z-index:1;
+  display:grid;
+  grid-template-columns:140px 1fr;
+  gap:18px;
+  align-items:start;
+}
+@media (max-width:620px){
+  .frog-card .row{ grid-template-columns:1fr; }
+  .frog-card .thumb-wrap{ justify-self:center; }
+}
+.frog-card .thumb-wrap{
+  width:140px;
+  min-width:140px;
+  height:140px;
+  position:relative;
+  border-radius:18px;
+  padding:6px;
+  background:linear-gradient(140deg, color-mix(in srgb, var(--card-2) 85%, transparent) 0%, color-mix(in srgb, var(--panelSoft) 80%, transparent) 100%);
+  box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--thumb-border, var(--border)) 65%, transparent);
+}
+.frog-card .thumb,
+.frog-card canvas.frog-canvas{
+  width:128px;
+  height:128px;
+  min-width:128px;
+  min-height:128px;
+  border-radius:14px;
+  object-fit:contain;
+  background:color-mix(in srgb, var(--panelSoft) 85%, transparent);
+  display:block;
+}
+.frog-card .title{
+  margin:0 0 6px 0;
+  font:800 18px/1.1 var(--font-display);
+  letter-spacing:-.01em;
+}
+.frog-card .pill{
+  font-size:12px;
+  padding:3px 10px;
+  border:1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  border-radius:999px;
+  background:linear-gradient(135deg, color-mix(in srgb, var(--accent) 18%, transparent) 0%, color-mix(in srgb, var(--accent) 6%, transparent) 100%);
+  color:var(--accent);
+  font-weight:700;
+  letter-spacing:.03em;
+  text-transform:uppercase;
+}
+.frog-card .pill.rk-legendary{ color:#facc15; border-color:color-mix(in srgb,#facc15 60%, transparent); }
+.frog-card .pill.rk-epic{ color:#a855f7; border-color:color-mix(in srgb,#a855f7 60%, transparent); }
+.frog-card .pill.rk-rare{ color:#38bdf8; border-color:color-mix(in srgb,#38bdf8 60%, transparent); }
+.frog-card .meta{
+  margin:0;
+  color:var(--fc-muted);
+  font-size:13px;
+  display:grid;
+  gap:4px;
+}
+.frog-card .meta .staked-flag{ color:#22c55e; font-weight:700; }
+.frog-card .meta .ago-line{ color:color-mix(in srgb, var(--fc-muted) 85%, #ffffff 5%); font-weight:600; }
+.frog-card .attr-bullets{
+  list-style:none;
+  margin:12px 0 0;
+  padding:0;
+  display:grid;
+  gap:8px;
+}
+.frog-card .attr-bullets li{
+  font-size:13px;
+  padding:9px 11px;
+  border-radius:12px;
+  background:color-mix(in srgb, var(--panelSoft) 80%, transparent);
+  border:1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  color:color-mix(in srgb, var(--ink) 82%, var(--muted));
+  display:flex;
+  gap:6px;
+  align-items:center;
+  transition:transform .2s ease, box-shadow .2s ease;
+}
+.frog-card .attr-bullets li b{
+  font-size:12px;
+  letter-spacing:.02em;
+}
 .frog-card .attr-bullets li[data-hoverable="1"]{ cursor:pointer; }
-.frog-card .actions{ display:flex; gap:8px; flex-wrap:wrap; margin-top:10px; }
-.frog-card .btn{ font-family:var(--font-ui); border:1px solid var(--border); background:transparent; color:inherit; border-radius:8px; padding:6px 10px; font-weight:700; font-size:12px; line-height:1; }
+.frog-card .attr-bullets li[data-hoverable="1"]:hover{
+  transform:translate(-4px,-6px);
+  box-shadow:0 16px 24px rgba(0,0,0,.35);
+}
+.frog-card .actions{
+  position:relative;
+  z-index:1;
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+  margin-top:18px;
+}
+.frog-card .btn{
+  font-family:var(--font-ui);
+  border:1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+  background:linear-gradient(135deg, color-mix(in srgb, var(--card-2) 75%, transparent) 0%, color-mix(in srgb, var(--panelSoft) 75%, transparent) 100%);
+  color:var(--ink);
+  border-radius:12px;
+  padding:7px 12px;
+  font-weight:700;
+  font-size:12px;
+  line-height:1;
+}
 .frog-card .btn:disabled{ opacity:.5; cursor:not-allowed; }
-.fc-level{ display:grid; grid-template-columns:auto 1fr auto; gap:8px; align-items:center; margin:4px 0 0; }
-.fc-level .lab{ font-size:12px; color:var(--muted); }
-.fc-level .val{ font-size:12px; font-weight:700; }
-.fc-level .bar{ height:6px; border:1px solid var(--border); border-radius:999px; background:color-mix(in srgb, var(--panel) 90%, transparent); overflow:hidden; }
-.fc-level .bar > i{ display:block; height:100%; width:0%; background:linear-gradient(90deg, #16a34a, #4ade80); }
-    `;
+.fc-level{
+  position:relative;
+  z-index:1;
+  display:grid;
+  grid-template-columns:auto 1fr auto;
+  gap:10px;
+  align-items:center;
+  margin:12px 0 0;
+}
+.fc-level .lab{ font-size:12px; color:var(--fc-muted); text-transform:uppercase; letter-spacing:.06em; }
+.fc-level .val{ font-size:12px; font-weight:700; color:var(--ink); }
+.fc-level .bar{
+  height:8px;
+  border:1px solid color-mix(in srgb, var(--card-frame) 40%, var(--border));
+  border-radius:999px;
+  background:color-mix(in srgb, var(--panelSoft) 86%, transparent);
+  overflow:hidden;
+}
+.fc-level .bar > i{
+  display:block;
+  height:100%;
+  width:0%;
+  background:linear-gradient(90deg, color-mix(in srgb, var(--accent) 80%, transparent), color-mix(in srgb, var(--accent) 35%, transparent));
+}
+`;
     const s = document.createElement('style');
-    s.id='ff-frog-cards-css'; s.textContent=css; document.head.appendChild(s);
+    s.id = 'ff-frog-cards-css';
+    s.textContent = css;
+    document.head.appendChild(s);
+  })();
+
+  (function ensureLayoutAttribute(){
+    const root = document.documentElement;
+    if (root && !root.getAttribute('data-card-layout')){
+      root.setAttribute('data-card-layout', 'classic');
+    }
   })();
 
   function imgFor(id){ return `${BASEPATH}/frog/${id}.png`; }
@@ -60,6 +211,48 @@
     const h=Math.floor((s%86400)/3600); if(h>=1) return h+'h ago';
     const m=Math.floor((s%3600)/60); if(m>=1) return m+'m ago';
     return s+'s ago';
+  }
+  function escapeHtml(str){
+    return String(str)
+      .replace(/&/g,'&amp;')
+      .replace(/</g,'&lt;')
+      .replace(/>/g,'&gt;')
+      .replace(/"/g,'&quot;')
+      .replace(/'/g,'&#39;');
+  }
+  function attrEscape(str){
+    return String(str).replace(/"/g,'&quot;');
+  }
+  function shortAddr(addr){
+    if(!addr||typeof addr!=='string') return '—';
+    const a = addr.trim();
+    if (!a) return '—';
+    if(a.length<=10) return a;
+    return a.slice(0,6)+'…'+a.slice(-4);
+  }
+  function ownerLabelFor(it){
+    if (it == null || typeof it !== 'object') return 'Unknown';
+    if (it.ownerLabel) return escapeHtml(it.ownerLabel);
+    if (it.ownerYou) return 'You';
+    if (it.ownerShort && it.ownerShort !== '—') return escapeHtml(it.ownerShort);
+    if (it.owner) return escapeHtml(shortAddr(it.owner));
+    if (it.holder) return escapeHtml(shortAddr(it.holder));
+    return 'Unknown';
+  }
+  function attrsFromMeta(meta){
+    const arr = meta && Array.isArray(meta.attributes) ? meta.attributes : null;
+    if (!arr || !arr.length) return null;
+    const out = [];
+    for (let i = 0; i < arr.length; i++){
+      const row = arr[i] || {};
+      const keyRaw = row.key ?? row.trait_type ?? row.traitType ?? row.type ?? null;
+      const valRaw = row.value ?? row.trait_value ?? row.traitValue ?? null;
+      const key = keyRaw != null ? String(keyRaw).trim() : '';
+      const val = valRaw != null ? String(valRaw).trim() : '';
+      if (!key || !val) continue;
+      out.push({ key, value: val });
+    }
+    return out.length ? out : null;
   }
   function levelInfo(sinceMs, secsPerLevel){
     if (!sinceMs) return { level:0, pct:0 };
@@ -81,15 +274,16 @@
     if (rank==null) return '';
     const t=tierFor(rank, tiers);
     const cls = t==='legendary'?'rk-legendary':t==='epic'?'rk-epic':t==='rare'?'rk-rare':'';
-    return ` <span class="pill ${cls}">Rank #${rank}</span>`;
+    return ` <span class="pill ${cls}">♦ #${rank}</span>`;
   }
   function attrsHTML(attrs, max=4){
     if (!Array.isArray(attrs)||!attrs.length) return '';
     const rows=[];
     for (let i=0;i<attrs.length;i++){
       const a = attrs[i]; if(!a.key||a.value==null) continue;
-      const hoverable = NO_HOVER_KEYS.has(a.key) ? '0' : '1';
-      rows.push(`<li data-attr-key="${String(a.key)}" data-hoverable="${hoverable}"><b>${a.key}:</b> ${String(a.value)}</li>`);
+      const keyStr = String(a.key);
+      const hoverable = NO_HOVER_KEYS.has(keyStr) ? '0' : '1';
+      rows.push(`<li data-attr-key="${attrEscape(keyStr)}" data-hoverable="${hoverable}"><b>${escapeHtml(keyStr)}:</b> ${escapeHtml(String(a.value))}</li>`);
       if(rows.length>=max) break;
     }
     return rows.length? '<ul class="attr-bullets">'+rows.join('')+'</ul>' : '';
@@ -146,11 +340,13 @@
     }
 
   function metaLineDefault(it){
+    const ownerLabel = ownerLabelFor(it);
     if (it.staked){
-      const ago = it.sinceMs ? fmtAgo(it.sinceMs) : null;
-      return (ago ? `Staked ${ago}` : 'Staked') + ' • Owned by You';
+      const agoRaw = it.sinceMs ? fmtAgo(it.sinceMs) : null;
+      const agoHtml = agoRaw ? `<span class="ago-line">${escapeHtml(agoRaw)}</span>` : '';
+      return `<span class="staked-flag">Staked</span> by ${ownerLabel}${agoHtml}`;
     }
-    return 'Not staked • Owned by You';
+    return 'Owned by ' + ownerLabel;
   }
 
   function levelRowHTML(it, secsPerLevel){
@@ -184,16 +380,16 @@
           <div class="meta">${metaLine}</div>
           ${levelRowHTML(item, secsPer)}
           ${attrs}
-          ${options.showActions ? `
-            <div class="actions">
-              <button class="btn" data-act="${item.staked ? 'unstake' : 'stake'}">${item.staked ? 'Unstake' : 'Stake'}</button>
-              <button class="btn" data-act="transfer" ${disableTransfer ? 'disabled title="Transfer disabled while staked"' : ''}>Transfer</button>
-              ${options.linkEtherscan !== false ? `<a class="btn" href="${(options.etherscanForId||etherscanFor)(item.id)}" target="_blank" rel="noopener">Etherscan</a>`:''}
-              ${options.linkOriginal !== false ? `<a class="btn" href="${(options.imgForId||imgFor)(item.id)}" target="_blank" rel="noopener">Original</a>`:''}
-            </div>
-          `:``}
         </div>
       </div>
+      ${options.showActions ? `
+        <div class="actions">
+          <button class="btn" data-act="${item.staked ? 'unstake' : 'stake'}">${item.staked ? 'Unstake' : 'Stake'}</button>
+          <button class="btn" data-act="transfer" ${disableTransfer ? 'disabled title="Transfer disabled while staked"' : ''}>Transfer</button>
+          ${options.linkEtherscan !== false ? `<a class="btn" href="${(options.etherscanForId||etherscanFor)(item.id)}" target="_blank" rel="noopener">Etherscan</a>`:''}
+          ${options.linkOriginal !== false ? `<a class="btn" href="${(options.imgForId||imgFor)(item.id)}" target="_blank" rel="noopener">Original</a>`:''}
+        </div>
+      `:``}
     `;
 
     // hover wiring (per attribute)
@@ -242,9 +438,18 @@
         id: Number(x.id),
         staked: !!x.staked,
         sinceMs: Number(x.sinceMs||0) || null,
-        attrs: Array.isArray(x.attrs)? x.attrs : [],
+        attrs: (()=>{
+          const metaAttrs = attrsFromMeta(x.metaRaw || null);
+          if (metaAttrs) return metaAttrs;
+          return Array.isArray(x.attrs)? x.attrs : [];
+        })(),
         rank: (x.rank==null? null : Number(x.rank)),
-        metaRaw: x.metaRaw || null
+        metaRaw: x.metaRaw || null,
+        owner: x.owner || null,
+        ownerShort: x.ownerShort || null,
+        ownerYou: !!x.ownerYou,
+        holder: x.holder || null,
+        ownerLabel: x.ownerLabel || null
       };
     }
     return null;
@@ -257,7 +462,15 @@
     return null;
   }
 
+  function normalizeLayoutId(id){
+    if (!id || typeof id !== 'string') return 'classic';
+    const lower = id.toLowerCase();
+    return CARD_LAYOUTS.indexOf(lower) >= 0 ? lower : 'classic';
+  }
+
   window.FF = window.FF || {};
+  window.FF.shortAddress = shortAddr;
+  window.FF.formatOwnerLine = metaLineDefault;
   window.FF.buildFrogCard = buildCard;
   window.FF.renderFrogCards = function renderFrogCards(container, frogs, options){
     const root = resolveContainer(container);
@@ -275,5 +488,22 @@
     for (const it of rows){
       root.appendChild(buildCard(it, opts));
     }
+  };
+  window.FF.setCardLayout = function setCardLayout(id){
+    const root = document.documentElement;
+    if (!root) return;
+    root.setAttribute('data-card-layout', normalizeLayoutId(id));
+  };
+  window.FF.getCardLayout = function getCardLayout(){
+    const root = document.documentElement;
+    if (!root) return 'classic';
+    return normalizeLayoutId(root.getAttribute('data-card-layout'));
+  };
+  window.FF.availableCardLayouts = function availableCardLayouts(){
+    return CARD_LAYOUTS.map((id)=>({ id, label: CARD_LAYOUT_LABELS[id] || id }));
+  };
+  window.FF.cardLayoutLabel = function cardLayoutLabel(id){
+    const key = normalizeLayoutId(id);
+    return CARD_LAYOUT_LABELS[key] || key;
   };
 })();

--- a/assets/js/rarity-page.js
+++ b/assets/js/rarity-page.js
@@ -1,355 +1,965 @@
-// assets/js/rarity-page.js
-// Rarity list that matches dashboard card visuals (rank pill tiers, staked line),
-// and uses the same 128×128 DOM layering from frog-renderer.js
+// assets/js/rarity-page.js — vanilla ES5-compatible rarity loader used by
+// rarity.html. This version intentionally avoids optional chaining, default
+// parameters, and other newer syntax so that the cards render in older
+// browsers.
 
-(function(FF = window.FF || {}, CFG = window.FF_CFG || {}) {
+(function(global){
   'use strict';
 
-  // ---------- DOM ----------
-  const GRID       = document.getElementById('rarityGrid');
-  const BTN_MORE   = document.getElementById('btnMore');
-  const BTN_RANK   = document.getElementById('btnSortRank');
-  const BTN_SCORE  = document.getElementById('btnSortScore');
-  const FIND_INPUT = document.getElementById('raritySearchId');
-  const BTN_GO     = document.getElementById('btnGo');
+  var FF  = global.FF     || {};
+  var CFG = global.FF_CFG || {};
+
+  var PAGE_CFG = global.FF_RARITY_PAGE_CONFIG || {};
+  try { delete global.FF_RARITY_PAGE_CONFIG; } catch (errCfg) {}
+
+  var GRID       = document.getElementById('rarityGrid');
+  var BTN_MORE   = document.getElementById('btnMore');
+  var BTN_RANK   = document.getElementById('btnSortRank');
+  var BTN_SCORE  = document.getElementById('btnSortScore');
+  var FIND_INPUT = document.getElementById('raritySearchId');
+  var BTN_GO     = document.getElementById('btnGo');
+  var BTN_THEME  = document.getElementById('btnThemeCycle');
   if (!GRID) return;
 
-  // ---------- Config ----------
-  const JSON_RANKS  = CFG.JSON_PATH || 'assets/freshfrogs_rarity_rankings.json'; // [{id, ranking, score}]
-  const LOOKUP_FILE = 'assets/freshfrogs_rank_lookup.json';                      // optional
-  const PAGE_SIZE   = 60;
-  const SIZE        = 128;
+  var PRIMARY_RANK_FILE = CFG.JSON_PATH || 'assets/freshfrogs_rarity_rankings.json';
+  var LOOKUP_FILE       = 'assets/freshfrogs_rank_lookup.json';
+  var STAKED_ONLY       = !!PAGE_CFG.stakedOnly;
+  var DEFAULT_SORT_MODE = (PAGE_CFG.defaultSortMode || 'rank');
+  var SECOND_SORT_MODE  = PAGE_CFG.secondSortMode === false ? null : (PAGE_CFG.secondSortMode || (STAKED_ONLY ? 'time' : 'score'));
+  var SECOND_SORT_LABEL = PAGE_CFG.secondSortLabel || null;
+  var AUTO_MIN_RENDER   = Number(PAGE_CFG.autoLoadMin) || 0;
+  DEFAULT_SORT_MODE = String(DEFAULT_SORT_MODE || 'rank').toLowerCase();
+  if (SECOND_SORT_MODE) SECOND_SORT_MODE = String(SECOND_SORT_MODE).toLowerCase();
+  var PAGE_SIZE         = Number(PAGE_CFG.pageSize || 60);
+  var SOURCE_PATH       = (CFG.SOURCE_PATH || '').replace(/\/+$/, '');
 
-  const RESERVOIR = {
-    HOST: (CFG.RESERVOIR_HOST || 'https://api.reservoir.tools').replace(/\/+$/,''),
-    KEY:  (CFG.FROG_API_KEY || CFG.RESERVOIR_API_KEY || '')
-  };
+  var RESERVOIR_HOST = (CFG.RESERVOIR_HOST || 'https://api.reservoir.tools').replace(/\/+$/, '');
+  var RESERVOIR_KEY  = CFG.FROG_API_KEY || CFG.RESERVOIR_API_KEY || '';
+  var CTRL_ADDR      = (CFG.CONTROLLER_ADDRESS || '').toLowerCase();
+  var CTRL_DEPLOY    = Number(CFG.CONTROLLER_DEPLOY_BLOCK);
 
-  // ---------- CSS (rank pill + green staked like dashboard) ----------
-  (function injectCSS(){
-    if (document.getElementById('rarity-cards-css')) return;
-    const css = `
-.frog-cards{ display:grid; gap:10px; }
-.frog-card{
-  border:1px solid var(--border);
-  background:var(--panel);
-  border-radius:14px;
-  padding:12px;
-  display:grid; grid-template-columns:auto 1fr; column-gap:12px; row-gap:6px; align-items:start;
-  color:inherit;
-}
-.frog-card .thumb-wrap{ width:${SIZE}px; min-width:${SIZE}px; position:relative; }
-.frog-card canvas.frog-canvas{ width:${SIZE}px; height:${SIZE}px; border-radius:12px; background:var(--panel-2); display:block; }
-.frog-card .title{ margin:0; font-weight:900; font-size:18px; letter-spacing:-.01em; display:flex; align-items:center; gap:8px; }
-.frog-card .meta{ color:var(--muted); font-size:12px; }
-.frog-card .attr-bullets{ list-style:disc; margin:6px 0 0 18px; padding:0; color:var(--muted); }
-.frog-card .attr-bullets li{ display:list-item; font-size:12px; margin:2px 0; }
-
-.rank-pill{
-  display:inline-flex; align-items:center; gap:6px;
-  border:1px solid var(--border); border-radius:999px; padding:3px 8px;
-  font-size:11px; font-weight:700; letter-spacing:.01em;
-  background:color-mix(in srgb, var(--panel) 35%, transparent);
-}
-.rank-pill::before{ content:'◆'; font-size:12px; line-height:1; }
-.rank-legendary{ color:#f59e0b; border-color: color-mix(in srgb, #f59e0b 70%, var(--border)); }
-.rank-legendary::before{ color:#f59e0b; }
-.rank-epic{ color:#a855f7; border-color: color-mix(in srgb, #a855f7 70%, var(--border)); }
-.rank-epic::before{ color:#a855f7; }
-.rank-rare{ color:#38bdf8; border-color: color-mix(in srgb, #38bdf8 70%, var(--border)); }
-.rank-rare::before{ color:#38bdf8; }
-.rank-common{ color:inherit; border-color:var(--border); }
-.rank-common::before{ color:var(--muted); }
-
-.meta .staked-flag{ color:#22c55e; font-weight:700; }
-.actions{ grid-column:1 / -1; display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
-.btn{ font-family:var(--font-ui); border:1px solid var(--border); background:transparent; color:inherit; border-radius:8px; padding:6px 10px; font-weight:700; font-size:12px; line-height:1; }
-.btn-outline-gray{ border-color: color-mix(in srgb, #9ca3af 70%, var(--border)); color: color-mix(in srgb, #ffffff 65%, #9ca3af); }
-    `;
-    const s=document.createElement('style'); s.id='rarity-cards-css'; s.textContent=css; document.head.appendChild(s);
-  })();
-
-  // ---------- Utils ----------
-  const asNum = (x)=> { const n = Number(x); return Number.isFinite(n)?n:NaN; };
-  const getRankLike = (o)=> asNum(o.rank ?? o.ranking ?? o.position ?? o.place);
-  const shortAddr = (a)=> a && typeof a==='string' ? (a.length>10 ? (a.slice(0,6)+'…'+a.slice(-4)) : a) : '—';
-  const traitKey  = (t)=> (t?.key ?? t?.trait_type ?? t?.traitType ?? t?.trait ?? '').toString().trim();
-  const traitVal  = (t)=> (t?.value ?? t?.trait_value ?? '').toString().trim();
-
-  // Same thresholds as dashboard (owned-panel.js)
-  function rankTier(rank){
-    const r = Number(rank);
-    if (!Number.isFinite(r)) return 'common';
-    const T = (CFG.RARITY_TIERS) || { legendary: 50, epic: 250, rare: 800 };
-    if (r <= T.legendary) return 'legendary';
-    if (r <= T.epic)      return 'epic';
-    if (r <= T.rare)      return 'rare';
-    return 'common';
+  var allItems   = [];
+  var viewItems  = [];
+  var offset     = 0;
+  var sortMode   = DEFAULT_SORT_MODE;
+  if (sortMode !== 'rank' && sortMode !== 'score' && sortMode !== 'time') {
+    sortMode = 'rank';
   }
-  function rankPill(rank){
-    const tier = rankTier(rank);
-    const span = document.createElement('span');
-    span.className = `rank-pill rank-${tier}`;
-    span.textContent = `#${rank}`;
-    return span;
-  }
-  function fmtAgo(ms){
-    if(!ms||!isFinite(ms))return null;
-    const s=Math.max(0,Math.floor((Date.now()-ms)/1000));
-    const d=Math.floor(s/86400); if(d>=1) return d+'d ago';
-    const h=Math.floor((s%86400)/3600);  if(h>=1) return h+'h ago';
-    const m=Math.floor((s%3600)/60);     if(m>=1) return m+'m ago';
-    return s+'s ago';
+  var renderCount = 0;
+  var lookupMap  = null; // Map<id, {rank, score}>
+  var currentUser = null;
+  var STORAGE_KEY_THEME = 'ff_rarity_theme';
+  var THEMES = [
+    { id: 'atlas',     label: 'Atlas Mint' },
+    { id: 'moonglow',  label: 'Moonglow Neon' },
+    { id: 'sunset',    label: 'Sunset Mirage' },
+    { id: 'evergreen', label: 'Evergreen Trail' },
+    { id: 'lilypad',   label: 'Lilypad Bloom' },
+    { id: 'abyss',     label: 'Abyssal Tide' },
+    { id: 'horizon',   label: 'High Horizon' },
+    { id: 'embercore', label: 'Ember Core' },
+    { id: 'frostbite', label: 'Frostbite Veil' },
+    { id: 'citrine',   label: 'Citrine Flash' },
+    { id: 'aurora',    label: 'Aurora Drift' },
+    { id: 'midnight',  label: 'Midnight Pulse' },
+    { id: 'opal',      label: 'Opal Gleam' },
+    { id: 'verdant',   label: 'Verdant Bloom' },
+    { id: 'royal',     label: 'Royal Crest' }
+  ];
+  var themeIndex = 0;
+
+  function uiError(msg) {
+    GRID.innerHTML = '<div class="pg-muted" style="padding:10px">' + msg + '</div>';
+    renderCount = 0;
   }
 
-  // owner logic
-  async function getUserAddress(){
-    try{ if (window.FF_WALLET?.address) return window.FF_WALLET.address; }catch{}
-    try{ if (window.ethereum?.request){ const a=await window.ethereum.request({method:'eth_accounts'}); return a?.[0]||null; } }catch{}
+  function clearGrid() {
+    GRID.innerHTML = '';
+    renderCount = 0;
+    if (GRID.classList && GRID.classList.add) {
+      GRID.classList.add('frog-cards');
+    }
+  }
+
+  function ensureMoreBtn() {
+    if (!BTN_MORE) return;
+    BTN_MORE.style.display = offset < viewItems.length ? 'inline-flex' : 'none';
+  }
+
+  function asNum(x) {
+    var n = Number(x);
+    return isFinite(n) ? n : NaN;
+  }
+
+  function labelForSort(mode) {
+    if (mode === 'rank') return 'Sort: Rank ↑';
+    if (mode === 'score') return 'Sort: Score ↓';
+    if (mode === 'time' || mode === 'stakedTime') return 'Sort: Time ↑';
+    return 'Sort';
+  }
+
+  function getRankLike(obj) {
+    if (!obj) return NaN;
+    if (obj.rank != null) return asNum(obj.rank);
+    if (obj.ranking != null) return asNum(obj.ranking);
+    if (obj.position != null) return asNum(obj.position);
+    if (obj.place != null) return asNum(obj.place);
+    return NaN;
+  }
+
+  function shortAddr(addr) {
+    if (!addr || typeof addr !== 'string') return '\u2014';
+    if (addr.length <= 10) return addr;
+    return addr.slice(0, 6) + '\u2026' + addr.slice(-4);
+  }
+
+  function traitKey(t) {
+    if (!t) return '';
+    var keys = ['key', 'trait_type', 'traitType', 'trait'];
+    for (var i = 0; i < keys.length; i++) {
+      if (t[keys[i]] != null) {
+        return String(t[keys[i]]).trim();
+      }
+    }
+    return '';
+  }
+
+  function traitVal(t) {
+    if (!t) return '';
+    var keys = ['value', 'trait_value'];
+    for (var i = 0; i < keys.length; i++) {
+      if (t[keys[i]] != null) {
+        return String(t[keys[i]]).trim();
+      }
+    }
+    return '';
+  }
+
+  function fmtAgo(ms) {
+    if (!ms || !isFinite(ms)) return null;
+    var s = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+    var d = Math.floor(s / 86400);
+    if (d >= 1) return d + 'd ago';
+    var h = Math.floor((s % 86400) / 3600);
+    if (h >= 1) return h + 'h ago';
+    var m = Math.floor((s % 3600) / 60);
+    if (m >= 1) return m + 'm ago';
+    return s + 's ago';
+  }
+
+  function sinceMs(sec) {
+    if (sec == null) return null;
+    var n = Number(sec);
+    if (!isFinite(n)) return null;
+    return n > 1e12 ? n : n * 1000;
+  }
+
+  function readStoredTheme() {
+    try {
+      if (global.localStorage) {
+        return global.localStorage.getItem(STORAGE_KEY_THEME);
+      }
+    } catch (err) {}
     return null;
   }
 
-  // On-chain owner (fallback to Reservoir)
-  let _web3,_col;
-  function getWeb3(){ if (_web3) return _web3; _web3 = new Web3(window.ethereum || Web3.givenProvider || ""); return _web3; }
-  function getCollectionContract(){
-    if (_col) return _col;
-    if (!CFG.COLLECTION_ADDRESS || !window.COLLECTION_ABI) return null;
-    _col = new (getWeb3()).eth.Contract(window.COLLECTION_ABI, CFG.COLLECTION_ADDRESS);
-    return _col;
-  }
-  async function ownerFromContract(id){
-    try{ const c=getCollectionContract(); if (!c) return null; return await c.methods.ownerOf(String(id)).call(); }
-    catch{ return null; }
-  }
-  async function ownerFromReservoir(id){
-    if (!RESERVOIR.KEY || !CFG.COLLECTION_ADDRESS) return null;
-    const url = `${RESERVOIR.HOST}/owners/v2?tokens=${encodeURIComponent(`${CFG.COLLECTION_ADDRESS}:${id}`)}&limit=1`;
-    try{
-      const r = await fetch(url, { headers: { accept:'application/json', 'x-api-key': RESERVOIR.KEY } });
-      if (!r.ok) return null;
-      const j = await r.json();
-      const own = j?.owners?.[0]?.owner;
-      return (typeof own==='string' && own.startsWith('0x')) ? own : null;
-    }catch{ return null; }
-  }
-  async function fetchOwnerOf(id){
-    const onchain = await ownerFromContract(id);
-    if (onchain) return onchain;
-    const api = await ownerFromReservoir(id);
-    return api || null;
-  }
-
-  // staking info (reuses any adapter if present)
-  async function fetchStakeInfo(id){
+  function storeTheme(id) {
     try {
-      if (FF.staking?.getStakeInfo) return await FF.staking.getStakeInfo(id);
-      if (window.STAKING_ADAPTER?.getStakeInfo) return await window.STAKING_ADAPTER.getStakeInfo(id);
-    } catch {}
-    return { staked:false, since:null };
+      if (global.localStorage) {
+        global.localStorage.setItem(STORAGE_KEY_THEME, id);
+      }
+    } catch (err) {}
   }
-  const sinceMs = (sec)=> {
-    if (sec==null) return null;
-    const n = Number(sec); if (!Number.isFinite(n)) return null;
-    return n > 1e12 ? n : n*1000;
-  };
 
-  // metadata
-  async function fetchMeta(id){
-    const tries = [
-      `frog/json/${id}.json`,
-      `frog/${id}.json`,
-      `assets/frogs/${id}.json`
-    ];
-    for (const u of tries){
-      try{ const r=await fetch(u,{cache:'no-store'}); if (r.ok) return await r.json(); }catch{}
+  function applyTheme(idx) {
+    if (!THEMES.length) return;
+    if (idx < 0) idx = 0;
+    if (idx >= THEMES.length) idx = 0;
+    themeIndex = idx;
+    var theme = THEMES[idx];
+    try {
+      if (document && document.documentElement) {
+        document.documentElement.setAttribute('data-theme', theme.id);
+      }
+    } catch (err1) {}
+    if (BTN_THEME) {
+      BTN_THEME.textContent = 'Theme: ' + theme.label + ' (' + (idx + 1) + '/' + THEMES.length + ')';
     }
-    return { name:`Frog #${id}`, attributes:[] };
+    storeTheme(theme.id);
   }
 
-  // ---------- Rankings ----------
-  async function fetchJSON(url){ const r=await fetch(url,{cache:'no-store'}); if(!r.ok) throw new Error(r.status); return r.json(); }
-  function normalizeRankingsArray(arr){
-    return arr.map(x => ({
-      id:   asNum(x.id ?? x.tokenId ?? x.token_id ?? x.frogId ?? x.frog_id),
-      rank: getRankLike(x),
-      score: asNum(x.score ?? x.rarityScore ?? x.points ?? 0)
-    }))
-    .filter(r => Number.isFinite(r.id) && Number.isFinite(r.rank) && r.rank>0)
-    .sort((a,b)=>a.rank-b.rank);
+  function applyThemeById(id) {
+    if (!id) {
+      applyTheme(0);
+      return;
+    }
+    for (var i = 0; i < THEMES.length; i++) {
+      if (THEMES[i].id === id) {
+        applyTheme(i);
+        return;
+      }
+    }
+    applyTheme(0);
   }
-  async function loadRankings(){
-    const primary = await fetchJSON(JSON_RANKS).catch(()=>[]);
-    let rows = Array.isArray(primary) ? normalizeRankingsArray(primary) : [];
-    if (!rows.length){
-      // optional lookup fallback
-      try{
-        const j = await fetchJSON(LOOKUP_FILE);
-        if (j && typeof j === 'object'){
-          rows = Object.entries(j).map(([rk,id])=>({ id: asNum(id), rank: asNum(rk), score: 0 }))
-                  .filter(r=>Number.isFinite(r.id)&&Number.isFinite(r.rank))
-                  .sort((a,b)=>a.rank-b.rank);
+
+  function initThemeCycle() {
+    if (!THEMES.length) return;
+    var startId = null;
+    try {
+      if (document && document.documentElement) {
+        startId = document.documentElement.getAttribute('data-theme');
+      }
+    } catch (err) {}
+    if (!startId) {
+      startId = readStoredTheme();
+    }
+    if (!startId) {
+      startId = THEMES[0].id;
+    }
+    applyThemeById(startId);
+    if (BTN_THEME) {
+      BTN_THEME.addEventListener('click', function(){
+        applyTheme((themeIndex + 1) % THEMES.length);
+      });
+    }
+  }
+
+  function getUserAddress() {
+    return new Promise(function(resolve){
+      try {
+        if (global.FF_WALLET && global.FF_WALLET.address) {
+          resolve(global.FF_WALLET.address);
+          return;
         }
-      }catch{}
-    }
-    return rows;
+      } catch (err) {}
+
+      try {
+        if (global.ethereum && typeof global.ethereum.request === 'function') {
+          global.ethereum.request({ method: 'eth_accounts' }).then(function(arr){
+            resolve(arr && arr.length ? arr[0] : null);
+          }).catch(function(){ resolve(null); });
+          return;
+        }
+      } catch (err2) {}
+
+      resolve(null);
+    });
   }
 
-  // ---------- Card ----------
-  function buildCard(rec, userAddr){
-    const { id, rank, meta, owner, stake } = rec;
-
-    const card = document.createElement('article');
-    card.className = 'frog-card';
-    card.setAttribute('data-token-id', String(id));
-
-    // media: host a hidden canvas; FF.renderFrog will stack DOM layers in the same order as metadata
-    const media = document.createElement('div');
-    media.className = 'thumb-wrap';
-    const cv = document.createElement('canvas');
-    cv.className = 'frog-canvas'; cv.width = SIZE; cv.height = SIZE;
-    media.appendChild(cv);
-
-    // title: Frog #id + rank pill (dashboard style)
-    const title = document.createElement('h4');
-    title.className = 'title';
-    title.textContent = meta?.name || `Frog #${id}`;
-    const pill = rankPill(rank);
-    title.appendChild(pill);
-
-    // subtitle: staked line + owner
-    const metaLine = document.createElement('div');
-    metaLine.className = 'meta';
-    const me = userAddr && owner && userAddr.toLowerCase() === owner.toLowerCase();
-
-    const stakeSpan = document.createElement('span');
-    if (stake?.staked) {
-      const ago = sinceMs(stake?.since) ? fmtAgo(sinceMs(stake?.since)) : null;
-      stakeSpan.className = 'staked-flag';
-      stakeSpan.textContent = ago ? `Staked ${ago}` : 'Staked';
-    } else {
-      stakeSpan.textContent = 'Not staked';
-    }
-    const sep = document.createElement('span'); sep.textContent = ' • ';
-    const ownerSpan = document.createElement('span');
-    ownerSpan.textContent = `Owned by ${me ? 'You' : shortAddr(owner)}`;
-
-    metaLine.appendChild(stakeSpan);
-    metaLine.appendChild(sep);
-    metaLine.appendChild(ownerSpan);
-
-    // attributes (vertical)
-    const list = document.createElement('ul');
-    list.className = 'attr-bullets';
-    (Array.isArray(meta?.attributes)? meta.attributes: []).forEach(a=>{
-      const k=traitKey(a), v=traitVal(a); if(!k||!v) return;
-      const li=document.createElement('li'); li.innerHTML = `<b>${k}:</b> ${v}`; list.appendChild(li);
+  function fetchJson(url) {
+    return fetch(url, { cache: 'no-store' }).then(function(res){
+      if (!res.ok) throw new Error('HTTP ' + res.status + ' fetching ' + url);
+      return res.json();
     });
+  }
 
-    // actions (view-only)
-    const actions = document.createElement('div'); actions.className='actions';
-    const aOS  = document.createElement('a'); aOS.className='btn btn-outline-gray'; aOS.textContent='OpenSea';
-    aOS.href = `https://opensea.io/assets/ethereum/${CFG.COLLECTION_ADDRESS}/${id}`; aOS.target='_blank'; aOS.rel='noopener';
-    const aScan= document.createElement('a'); aScan.className='btn btn-outline-gray'; aScan.textContent='Etherscan';
-    aScan.href = `https://etherscan.io/token/${CFG.COLLECTION_ADDRESS}?a=${id}`; aScan.target='_blank'; aScan.rel='noopener';
-    const aOrig= document.createElement('a'); aOrig.className='btn btn-outline-gray'; aOrig.textContent='Original';
-    aOrig.href = `frog/${id}.png`; aOrig.target='_blank'; aOrig.rel='noopener';
-    actions.appendChild(aOS); actions.appendChild(aScan); actions.appendChild(aOrig);
+  function parseRankToIdMap(obj) {
+    var map = new Map();
+    for (var key in obj) {
+      if (!obj.hasOwnProperty(key)) continue;
+      var rank = asNum(key);
+      var id = asNum(obj[key]);
+      if (isFinite(rank) && isFinite(id)) {
+        map.set(id, { rank: rank, score: 0 });
+      }
+    }
+    return map.size ? map : null;
+  }
 
-    // compose
-    card.appendChild(media);
-    const right = document.createElement('div');
+  function normalizeRankingsArray(arr) {
+    return arr
+      .map(function(x){
+        var id = asNum(x && (x.id != null ? x.id : (x.tokenId != null ? x.tokenId : (x.token_id != null ? x.token_id : (x.frogId != null ? x.frogId : x.frog_id)))));
+        var rank = getRankLike(x);
+        var score = asNum(x && (x.score != null ? x.score : (x.rarityScore != null ? x.rarityScore : x.points)));
+        if (!isFinite(score)) score = 0;
+        return { id: id, rank: rank, score: score };
+      })
+      .filter(function(r){ return isFinite(r.id) && isFinite(r.rank) && r.rank > 0; })
+      .sort(function(a, b){ return a.rank - b.rank; });
+  }
+
+  function loadLookup() {
+    return fetchJson(LOOKUP_FILE).then(function(json){
+      if (Array.isArray(json)) {
+        var map = new Map();
+        for (var i = 0; i < json.length; i++) {
+          var id = asNum(json[i]);
+          if (isFinite(id)) map.set(id, { rank: i + 1, score: 0 });
+        }
+        lookupMap = map.size ? map : null;
+      } else if (json && typeof json === 'object') {
+        lookupMap = parseRankToIdMap(json);
+      } else {
+        lookupMap = null;
+      }
+    }).catch(function(err){
+      console.warn('[rarity] lookup load failed', err);
+      lookupMap = null;
+    });
+  }
+
+  function loadPrimaryRanks() {
+    return fetchJson(PRIMARY_RANK_FILE).then(function(json){
+      if (!Array.isArray(json)) return [];
+      var arr = normalizeRankingsArray(json);
+      if (lookupMap) {
+        arr.forEach(function(r){
+          var lk = lookupMap.get(r.id);
+          if (!lk) return;
+          if (!isFinite(r.rank) && isFinite(lk.rank)) r.rank = lk.rank;
+          if (!isFinite(r.score) && isFinite(lk.score)) r.score = lk.score;
+        });
+        arr.sort(function(a, b){ return a.rank - b.rank; });
+      }
+      return arr;
+    }).catch(function(err){
+      console.warn('[rarity] primary rankings load failed', err);
+      return [];
+    });
+  }
+
+  function fetchMeta(id) {
+    var tries = [
+      'frog/json/' + id + '.json',
+      'frog/' + id + '.json',
+      'assets/frogs/' + id + '.json'
+    ];
+
+    var next = function(ix){
+      if (ix >= tries.length) {
+        return Promise.resolve({ name: 'Frog #' + id, image: 'frog/' + id + '.png', attributes: [] });
+      }
+      var url = tries[ix];
+      return fetch(url, { cache: 'no-store' }).then(function(res){
+        if (!res.ok) return next(ix + 1);
+        return res.json();
+      }).catch(function(){
+        return next(ix + 1);
+      });
+    };
+
+    return next(0);
+  }
+
+  function normalizeAttrs(meta) {
+    var out = [];
+    var arr = meta && Array.isArray(meta.attributes) ? meta.attributes : [];
+    for (var i = 0; i < arr.length; i++) {
+      var key = traitKey(arr[i]);
+      var val = traitVal(arr[i]);
+      if (!key || !val) continue;
+      out.push({ key: key, value: val });
+    }
+    return out;
+  }
+
+  var _web3 = null;
+  var _collection = null;
+  var _controller = null;
+  var _stakeSinceCache = new Map();
+  var _stakerCache = new Map();
+
+  function getWeb3(){
+    if (_web3) return _web3;
+    if (!global.Web3) return null;
+
+    var provider = null;
+    if (global.ethereum) {
+      provider = global.ethereum;
+    } else if (global.Web3.givenProvider) {
+      provider = global.Web3.givenProvider;
+    } else if (CFG.RPC_URL && global.Web3 && global.Web3.providers && global.Web3.providers.HttpProvider) {
+      try {
+        provider = new global.Web3.providers.HttpProvider(CFG.RPC_URL);
+      } catch (err) {
+        console.warn('[rarity] failed to build HttpProvider', err);
+      }
+    }
+
+    if (!provider) return null;
+
+    _web3 = new global.Web3(provider);
+    return _web3;
+  }
+
+  function resolveCollectionAbi(){
+    if (typeof global.COLLECTION_ABI !== 'undefined') return global.COLLECTION_ABI;
+    if (typeof global.collection_abi !== 'undefined') return global.collection_abi;
+    if (typeof COLLECTION_ABI !== 'undefined') return COLLECTION_ABI;
+    if (typeof collection_abi !== 'undefined') return collection_abi;
+    return null;
+  }
+
+  function resolveControllerAbi(){
+    if (typeof global.CONTROLLER_ABI !== 'undefined') return global.CONTROLLER_ABI;
+    if (typeof global.controller_abi !== 'undefined') return global.controller_abi;
+    if (typeof CONTROLLER_ABI !== 'undefined') return CONTROLLER_ABI;
+    if (typeof controller_abi !== 'undefined') return controller_abi;
+    return null;
+  }
+
+  function getCollectionContract(){
+    if (_collection) return _collection;
+    if (!CFG.COLLECTION_ADDRESS) return null;
+    var abi = resolveCollectionAbi();
+    if (!abi || !abi.length) return null;
+    var web3 = getWeb3();
+    if (!web3 || !web3.eth || !web3.eth.Contract) return null;
+    _collection = new web3.eth.Contract(abi, CFG.COLLECTION_ADDRESS);
+    return _collection;
+  }
+
+  function getControllerContract(){
+    if (_controller) return _controller;
+    if (!CFG.CONTROLLER_ADDRESS) return null;
+    var abi = resolveControllerAbi();
+    if (!abi || !abi.length) return null;
+    var web3 = getWeb3();
+    if (!web3 || !web3.eth || !web3.eth.Contract) return null;
+    _controller = new web3.eth.Contract(abi, CFG.CONTROLLER_ADDRESS);
+    return _controller;
+  }
+
+  function isHexAddress(addr){
+    return typeof addr === 'string' && addr.indexOf('0x') === 0 && addr.length === 42;
+  }
+
+  function padTokenHex(id){
+    var n = Number(id);
+    if (!isFinite(n) || n < 0) n = 0;
+    var hex = n.toString(16);
+    while (hex.length < 64) hex = '0' + hex;
+    return '0x' + hex;
+  }
+
+  function fetchStakeTimestamp(id){
+    if (_stakeSinceCache.has(id)) return Promise.resolve(_stakeSinceCache.get(id));
+
+    return new Promise(function(resolve){
+      try {
+        var web3 = getWeb3();
+        if (!web3 || !web3.eth || !web3.eth.getPastLogs || !CFG.COLLECTION_ADDRESS || !CTRL_ADDR) {
+          _stakeSinceCache.set(id, null);
+          resolve(null);
+          return;
+        }
+
+        var topics = [
+          '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+          null,
+          '0x000000000000000000000000' + CTRL_ADDR.slice(2),
+          padTokenHex(id)
+        ];
+
+        var fromBlock = isFinite(CTRL_DEPLOY) && CTRL_DEPLOY > 0 ? '0x' + CTRL_DEPLOY.toString(16) : '0x0';
+
+        web3.eth.getPastLogs({
+          fromBlock: fromBlock,
+          toBlock: 'latest',
+          address: CFG.COLLECTION_ADDRESS,
+          topics: topics
+        }).then(function(logs){
+          if (!logs || !logs.length) {
+            _stakeSinceCache.set(id, null);
+            resolve(null);
+            return;
+          }
+          var last = logs[logs.length - 1];
+          web3.eth.getBlock(last.blockNumber).then(function(block){
+            var ts = block && block.timestamp != null ? Number(block.timestamp) : null;
+            var ms = ts ? (ts > 1e12 ? ts : ts * 1000) : null;
+            _stakeSinceCache.set(id, ms);
+            resolve(ms);
+          }).catch(function(err){
+            console.warn('[rarity] stake block lookup failed', err);
+            _stakeSinceCache.set(id, null);
+            resolve(null);
+          });
+        }).catch(function(err2){
+          console.warn('[rarity] stake log lookup failed', err2);
+          _stakeSinceCache.set(id, null);
+          resolve(null);
+        });
+      } catch (err3) {
+        console.warn('[rarity] stake timestamp error', err3);
+        _stakeSinceCache.set(id, null);
+        resolve(null);
+      }
+    });
+  }
+
+  function fetchStakerAddress(id){
+    if (_stakerCache.has(id)) return Promise.resolve(_stakerCache.get(id));
+
+    return new Promise(function(resolve){
+      try {
+        var ctrl = getControllerContract();
+        if (!ctrl || !ctrl.methods || !ctrl.methods.stakerAddress) {
+          _stakerCache.set(id, null);
+          resolve(null);
+          return;
+        }
+        ctrl.methods.stakerAddress(String(id)).call().then(function(addr){
+          if (!addr || !isHexAddress(addr) || addr === '0x0000000000000000000000000000000000000000') {
+            _stakerCache.set(id, null);
+            resolve(null);
+            return;
+          }
+          _stakerCache.set(id, addr);
+          resolve(addr);
+        }).catch(function(err){
+          console.warn('[rarity] staker lookup failed', err);
+          _stakerCache.set(id, null);
+          resolve(null);
+        });
+      } catch (err2) {
+        console.warn('[rarity] staker error', err2);
+        _stakerCache.set(id, null);
+        resolve(null);
+      }
+    });
+  }
+
+  function ownerFromContract(id){
+    return new Promise(function(resolve){
+      try {
+        var contract = getCollectionContract();
+        if (!contract) { resolve(null); return; }
+        contract.methods.ownerOf(String(id)).call().then(function(addr){
+          resolve(addr || null);
+        }).catch(function(){ resolve(null); });
+      } catch (err) {
+        resolve(null);
+      }
+    });
+  }
+
+  function ownerFromReservoir(id){
+    if (!RESERVOIR_KEY || !CFG.COLLECTION_ADDRESS) return Promise.resolve(null);
+    var token = CFG.COLLECTION_ADDRESS + ':' + id;
+    var url = RESERVOIR_HOST + '/owners/v2?tokens=' + encodeURIComponent(token) + '&limit=1';
+    return fetch(url, {
+      headers: {
+        accept: 'application/json',
+        'x-api-key': RESERVOIR_KEY
+      }
+    }).then(function(res){
+      if (!res.ok) return null;
+      return res.json();
+    }).then(function(json){
+      if (!json || !json.owners || !json.owners.length) return null;
+      var owner = json.owners[0] && json.owners[0].owner;
+      return (typeof owner === 'string' && owner.indexOf('0x') === 0) ? owner : null;
+    }).catch(function(err){
+      console.warn('[rarity] reservoir owner lookup failed', err);
+      return null;
+    });
+  }
+
+  function fetchOwnerOf(id){
+    return ownerFromContract(id).then(function(onchain){
+      var holder = isHexAddress(onchain) ? onchain : null;
+      var controllerOwned = !!(holder && CTRL_ADDR && holder.toLowerCase() === CTRL_ADDR);
+
+      if (controllerOwned) {
+        return fetchStakerAddress(id).then(function(staker){
+          return (staker ? Promise.resolve(staker) : ownerFromReservoir(id)).then(function(ownerGuess){
+            return fetchStakeTimestamp(id).then(function(since){
+              return {
+                owner: staker || ownerGuess || null,
+                holder: holder,
+                controllerOwned: true,
+                stakeSinceMs: since,
+                staker: staker || null
+              };
+            });
+          });
+        });
+      }
+
+      if (holder) {
+        return {
+          owner: holder,
+          holder: holder,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      }
+
+      return ownerFromReservoir(id).then(function(resOwner){
+        return {
+          owner: resOwner || null,
+          holder: holder,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      });
+    }).catch(function(err){
+      console.warn('[rarity] owner lookup fallback', err);
+      return ownerFromReservoir(id).then(function(resOwner){
+        return {
+          owner: resOwner || null,
+          holder: null,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      }).catch(function(){
+        return {
+          owner: null,
+          holder: null,
+          controllerOwned: false,
+          stakeSinceMs: null,
+          staker: null
+        };
+      });
+    });
+  }
+
+  function fetchStakeInfo(id){
+    return new Promise(function(resolve){
+      var done = false;
+      function finish(info){
+        if (done) return;
+        done = true;
+        resolve(info || { staked: false, since: null });
+      }
+
+      try {
+        if (FF.staking && typeof FF.staking.getStakeInfo === 'function') {
+          FF.staking.getStakeInfo(id).then(function(info){ finish(info); }).catch(function(){ finish(null); });
+          return;
+        }
+      } catch (err) {
+        console.warn('[rarity] staking info via FF.staking failed', err);
+      }
+
+      try {
+        if (global.STAKING_ADAPTER && typeof global.STAKING_ADAPTER.getStakeInfo === 'function') {
+          global.STAKING_ADAPTER.getStakeInfo(id).then(function(info){ finish(info); }).catch(function(){ finish(null); });
+          return;
+        }
+      } catch (err2) {
+        console.warn('[rarity] staking adapter lookup failed', err2);
+      }
+
+      finish(null);
+    });
+  }
+
+  function normalizeStake(info){
+    var staked = info && !!info.staked;
+    var since = null;
+    if (info) {
+      if (info.since != null) since = info.since;
+      else if (info.sinceMs != null) since = info.sinceMs;
+      else if (info.since_ms != null) since = info.since_ms;
+      else if (info.stakedSince != null) since = info.stakedSince;
+    }
+    return { staked: staked, sinceMs: sinceMs(since) };
+  }
+
+  function fallbackMetaLine(item){
+    var ownerLabel = null;
+    if (item.ownerYou) ownerLabel = 'You';
+    else if (item.ownerShort && item.ownerShort !== '\u2014') ownerLabel = item.ownerShort;
+    else if (item.owner) ownerLabel = shortAddr(item.owner);
+    else if (item.holder) ownerLabel = shortAddr(item.holder);
+    if (!ownerLabel) ownerLabel = 'Unknown';
+    if (item.staked) {
+      var ago = item.sinceMs ? fmtAgo(item.sinceMs) : null;
+      var agoHtml = ago ? ('<span class="ago-line">' + ago + '</span>') : '';
+      return '<span class="staked-flag">Staked</span> by ' + ownerLabel + agoHtml;
+    }
+    return 'Owned by ' + ownerLabel;
+  }
+
+  function metaLineForCard(item){
+    try {
+      if (global.FF && typeof global.FF.formatOwnerLine === 'function') {
+        return global.FF.formatOwnerLine(item);
+      }
+    } catch (err) {
+      console.warn('[rarity] meta line formatter failed', err);
+    }
+    return fallbackMetaLine(item);
+  }
+
+  function buildFallbackCard(rec) {
+    var card = document.createElement('article');
+    card.className = 'frog-card';
+    card.setAttribute('data-token-id', String(rec.id));
+
+    var row = document.createElement('div');
+    row.className = 'row';
+
+    var thumbWrap = document.createElement('div');
+    thumbWrap.className = 'thumb-wrap';
+
+    var img = document.createElement('img');
+    img.className = 'thumb';
+    img.alt = (rec.metaRaw && rec.metaRaw.name) ? rec.metaRaw.name : ('Frog #' + rec.id);
+    img.loading = 'lazy';
+    img.src = (rec.metaRaw && rec.metaRaw.image) ? rec.metaRaw.image : (SOURCE_PATH + '/frog/' + rec.id + '.png');
+    thumbWrap.appendChild(img);
+
+    var right = document.createElement('div');
+    var title = document.createElement('h4');
+    title.className = 'title';
+    title.textContent = (rec.metaRaw && rec.metaRaw.name) ? rec.metaRaw.name : ('Frog #' + rec.id);
+    if (rec.rank != null) {
+      var pill = document.createElement('span');
+      pill.className = 'pill';
+      pill.textContent = '♦ #' + rec.rank;
+      title.appendChild(pill);
+    }
+    var metaLine = document.createElement('div');
+    metaLine.className = 'meta';
+    metaLine.innerHTML = metaLineForCard(rec);
+
     right.appendChild(title);
     right.appendChild(metaLine);
-    if (list.childNodes.length) right.appendChild(list);
-    right.appendChild(actions);
-    card.appendChild(right);
 
-    // render layered frog (metadata order) at 128×128
-    (async ()=>{
-      try{
-        await (FF.renderFrog ? FF.renderFrog(cv, rec.metaRaw || meta, { size: SIZE, tokenId: id }) : Promise.reject());
-      }catch{
-        // fallback to still image if renderer not available
-        const img = document.createElement('img'); img.src = `frog/${id}.png`; img.alt = String(id); img.className = 'frog-canvas';
-        media.innerHTML=''; media.appendChild(img);
-      }
-    })();
+    if (rec.attrs && rec.attrs.length) {
+      var list = document.createElement('ul');
+      list.className = 'attr-bullets';
+      rec.attrs.forEach(function(attr){
+        var li = document.createElement('li');
+        li.innerHTML = '<b>' + attr.key + ':</b> ' + attr.value;
+        list.appendChild(li);
+      });
+      right.appendChild(list);
+    }
 
+    row.appendChild(thumbWrap);
+    row.appendChild(right);
+    card.appendChild(row);
     return card;
   }
 
-  // ---------- Paging / render ----------
-  let rows=[], view=[], offset=0, sortMode='rank';
-  function ensureMoreBtn(){ if (BTN_MORE) BTN_MORE.style.display = offset < view.length ? 'inline-flex' : 'none'; }
-  function clearGrid(){ GRID.innerHTML=''; GRID.classList.add('frog-cards'); }
+  function buildCard(rec) {
+    if (global.FF && typeof global.FF.buildFrogCard === 'function') {
+      return global.FF.buildFrogCard({
+        id: rec.id,
+        rank: rec.rank,
+        attrs: rec.attrs,
+        staked: rec.staked,
+        sinceMs: rec.sinceMs,
+        metaRaw: rec.metaRaw,
+        owner: rec.owner,
+        ownerShort: rec.ownerShort,
+        ownerYou: rec.ownerYou,
+        holder: rec.holder
+      }, {
+        showActions: false,
+        rarityTiers: CFG.RARITY_TIERS,
+        metaLine: metaLineForCard
+      });
+    }
+    return buildFallbackCard(rec);
+  }
 
-  async function loadMore(userAddr){
-    const slice = view.slice(offset, offset + PAGE_SIZE);
-    if (!slice.length) { ensureMoreBtn(); return; }
-
-    const metas  = await Promise.all(slice.map(x => fetchMeta(x.id)));
-    const owners = await Promise.all(slice.map(x => fetchOwnerOf(x.id)));
-    const stakes = await Promise.all(slice.map(x => fetchStakeInfo(x.id)));
-
-    for (let i=0;i<slice.length;i++){
-      slice[i].meta = metas[i];
-      slice[i].metaRaw = metas[i]; // pass through for renderer
-      slice[i].owner = owners[i] || null;
-      slice[i].stake = stakes[i] || {staked:false, since:null};
+  function loadMore() {
+    var slice = viewItems.slice(offset, offset + PAGE_SIZE);
+    if (!slice.length) {
+      ensureMoreBtn();
+      return Promise.resolve();
     }
 
-    const frag=document.createDocumentFragment();
-    slice.forEach(rec => frag.appendChild(buildCard(rec, userAddr)));
-    GRID.appendChild(frag);
+    return Promise.all(slice.map(function(x){ return fetchMeta(x.id); }))
+      .then(function(metas){
+        return Promise.all(slice.map(function(x){ return fetchOwnerOf(x.id); })).then(function(owners){
+          return Promise.all(slice.map(function(x){ return fetchStakeInfo(x.id); })).then(function(stakes){
+            var frag = document.createDocumentFragment();
+            var appended = 0;
+            for (var i = 0; i < slice.length; i++) {
+              var meta = metas[i] || { attributes: [] };
+              var ownerInfo = owners[i] || {};
+              if (ownerInfo && typeof ownerInfo === 'string') {
+                ownerInfo = { owner: ownerInfo, holder: ownerInfo, controllerOwned: false, stakeSinceMs: null, staker: null };
+              }
+              var stake = normalizeStake(stakes[i] || null);
+              var attrs = normalizeAttrs(meta);
 
-    offset += slice.length;
-    ensureMoreBtn();
+              var isStaked = stake.staked || !!ownerInfo.controllerOwned;
+              var since = stake.sinceMs || ownerInfo.stakeSinceMs || null;
+              var actualOwner = ownerInfo.owner || null;
+              if (!actualOwner && !isStaked && ownerInfo.holder) {
+                actualOwner = ownerInfo.holder;
+              }
+              if (!actualOwner && ownerInfo.staker) {
+                actualOwner = ownerInfo.staker;
+              }
+
+              var ownerShort = actualOwner ? shortAddr(actualOwner) : null;
+              var ownerYou = false;
+              if (currentUser && actualOwner && typeof currentUser === 'string' && typeof actualOwner === 'string') {
+                ownerYou = currentUser.toLowerCase() === actualOwner.toLowerCase();
+              } else if (currentUser && !actualOwner && ownerInfo.holder && typeof ownerInfo.holder === 'string') {
+                ownerYou = currentUser.toLowerCase() === ownerInfo.holder.toLowerCase();
+              }
+
+              slice[i].staked = isStaked;
+              slice[i].sinceMs = since;
+              slice[i].owner = actualOwner;
+              slice[i].ownerShort = ownerShort;
+              slice[i].ownerYou = ownerYou;
+              slice[i].holder = ownerInfo && ownerInfo.holder ? ownerInfo.holder : null;
+              slice[i].metaRaw = meta;
+              slice[i].attrs = attrs;
+
+              if (STAKED_ONLY && !isStaked) {
+                continue;
+              }
+
+              var rec = {
+                id: slice[i].id,
+                rank: slice[i].rank,
+                score: slice[i].score,
+                metaRaw: meta,
+                attrs: attrs,
+                staked: isStaked,
+                sinceMs: since,
+                owner: actualOwner,
+                ownerShort: ownerShort,
+                ownerYou: ownerYou,
+                holder: ownerInfo && ownerInfo.holder ? ownerInfo.holder : null
+              };
+              frag.appendChild(buildCard(rec));
+              appended += 1;
+            }
+
+            if (appended) {
+              GRID.appendChild(frag);
+              renderCount += appended;
+            }
+            offset += slice.length;
+            ensureMoreBtn();
+            if (STAKED_ONLY) {
+              if (!appended && offset < viewItems.length) {
+                return loadMore();
+              }
+              if (!appended && offset >= viewItems.length && renderCount === 0) {
+                uiError('No staked frogs found.');
+                if (BTN_MORE) BTN_MORE.style.display = 'none';
+                return;
+              }
+              if (AUTO_MIN_RENDER > 0 && renderCount < AUTO_MIN_RENDER && offset < viewItems.length) {
+                return loadMore();
+              }
+            }
+          });
+        });
+      }).catch(function(err){
+        console.error('[rarity] loadMore failed', err);
+        uiError('Failed to load frogs.');
+      });
   }
 
-  function resort(userAddr){
-    view.sort((a,b)=> sortMode==='rank'
-      ? (a.rank - b.rank)
-      : ((b.score - a.score) || (a.rank - b.rank))
-    );
-    offset = 0; clearGrid(); loadMore(userAddr);
+  function resort() {
+    viewItems.sort(function(a, b){
+      var aRank = (a && a.rank != null) ? a.rank : Number.POSITIVE_INFINITY;
+      var bRank = (b && b.rank != null) ? b.rank : Number.POSITIVE_INFINITY;
+      if (sortMode === 'time') {
+        var aStaked = !!(a && a.staked);
+        var bStaked = !!(b && b.staked);
+        if (aStaked !== bStaked) {
+          return bStaked - aStaked;
+        }
+        var ta = (a && a.sinceMs != null) ? a.sinceMs : null;
+        var tb = (b && b.sinceMs != null) ? b.sinceMs : null;
+        if (ta == null && tb != null) return 1;
+        if (tb == null && ta != null) return -1;
+        if (ta != null && tb != null && ta !== tb) return ta - tb;
+        return aRank - bRank;
+      }
+      if (sortMode === 'score') {
+        var sa = (a && a.score != null) ? a.score : -Infinity;
+        var sb = (b && b.score != null) ? b.score : -Infinity;
+        var diff = (sb - sa);
+        if (diff) return diff;
+        return aRank - bRank;
+      }
+      return aRank - bRank;
+    });
+    offset = 0;
+    clearGrid();
+    loadMore();
   }
 
-  function jumpToId(id, userAddr){
-    const ix = view.findIndex(x => x.id === id);
+  function jumpToId(id) {
+    var ix = -1;
+    for (var i = 0; i < viewItems.length; i++) {
+      if (viewItems[i].id === id) { ix = i; break; }
+    }
     if (ix < 0) return;
     offset = Math.floor(ix / PAGE_SIZE) * PAGE_SIZE;
-    clearGrid(); loadMore(userAddr);
+    clearGrid();
+    loadMore();
   }
 
-  // ---------- Init ----------
-  (async function init(){
-    try{
-      rows = await loadRankings();
-      if (!rows.length){
-        GRID.innerHTML = `<div class="pg-muted" style="padding:10px">Could not load rarity data. Check JSON files and try a hard refresh.</div>`;
-        return;
+  function init() {
+    loadLookup().then(function(){
+      return loadPrimaryRanks();
+    }).then(function(primary){
+      if (primary && primary.length) {
+        allItems = primary;
+      } else if (lookupMap && lookupMap.size) {
+        allItems = Array.from(lookupMap).map(function(entry){
+          return { id: entry[0], rank: entry[1].rank, score: entry[1].score || 0 };
+        }).sort(function(a, b){ return a.rank - b.rank; });
+      } else {
+        uiError('Could not load rarity data. Check both JSON files\' shapes.');
+        return null;
       }
-      view = rows.slice();
-      offset = 0; clearGrid();
 
-      const userAddr = await getUserAddress();
-      await loadMore(userAddr);
-      BTN_MORE && (BTN_MORE.style.display = 'inline-flex');
+      viewItems = allItems.slice(0);
+      offset = 0;
+      clearGrid();
 
-      BTN_MORE?.addEventListener('click', () => loadMore(userAddr));
-      BTN_RANK?.addEventListener('click', ()=>{ sortMode='rank'; resort(userAddr); });
-      BTN_SCORE?.addEventListener('click', ()=>{ sortMode='score'; resort(userAddr); });
-      BTN_GO?.addEventListener('click', ()=>{
-        const id = Number(FIND_INPUT.value);
-        if (Number.isFinite(id)) jumpToId(id, userAddr);
+      return getUserAddress().then(function(addr){
+        currentUser = addr;
+        return loadMore();
+      });
+    }).then(function(){
+      if (BTN_MORE) BTN_MORE.style.display = 'inline-flex';
+
+      if (BTN_MORE) BTN_MORE.addEventListener('click', function(){ loadMore(); });
+      if (BTN_RANK) {
+        BTN_RANK.textContent = labelForSort('rank');
+        BTN_RANK.addEventListener('click', function(){ sortMode = 'rank'; resort(); });
+      }
+      if (BTN_SCORE) {
+        if (!SECOND_SORT_MODE) {
+          BTN_SCORE.style.display = 'none';
+        } else {
+          BTN_SCORE.textContent = SECOND_SORT_LABEL || labelForSort(SECOND_SORT_MODE);
+          BTN_SCORE.addEventListener('click', function(){ sortMode = SECOND_SORT_MODE; resort(); });
+        }
+      }
+      if (BTN_GO) BTN_GO.addEventListener('click', function(){
+        var id = Number(FIND_INPUT && FIND_INPUT.value);
+        if (isFinite(id)) jumpToId(id);
       });
 
-      if (window.ethereum?.on) window.ethereum.on('accountsChanged', ()=> location.reload());
-    }catch(e){
-      console.error('[rarity] init failed', e);
-      GRID.innerHTML = `<div class="pg-muted" style="padding:10px">Failed to initialize rarity view.</div>`;
-    }
-  })();
+      if (global.ethereum && typeof global.ethereum.on === 'function') {
+        global.ethereum.on('accountsChanged', function(){ global.location.reload(); });
+      }
+    }).catch(function(err){
+      console.error('[rarity] init error', err);
+      uiError('Failed to initialize rarity view. See console for details.');
+    });
+  }
 
-})(window.FF, window.FF_CFG);
+  initThemeCycle();
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})(window);

--- a/collection.html
+++ b/collection.html
@@ -221,13 +221,10 @@
 <script src="assets/js/staking-adapter.js"></script>  <!-- ✅ correct path -->
 <script src="assets/js/pond-kpis.js"></script>
 <script src="assets/js/topbar.js"></script>
-<script src="assets/js/frog-renderer.js"></script>
-<script src="assets/js/frog-cards.js" defer></script>
 <script src="assets/js/stakes-feed.js"></script>
 <script src="assets/js/pond-tweaks.js"></script>
 <script src="assets/js/owned-panel.js"></script>
 <script src="assets/js/frog-thumbs.js"></script>
-
 <script>
   if (window.FF_loadRecentStakes) FF_loadRecentStakes();
   if (window.FF_initOwnedPanel)   FF_initOwnedPanel();

--- a/layouts/layout-01-classic.html
+++ b/layouts/layout-01-classic.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Classic Layout</title>
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <style>
+    body{ background:var(--bg); color:var(--text); font-family:var(--font-ui); }
+    .wrap{ max-width:1100px; margin:0 auto; padding:32px 16px; display:grid; gap:24px; }
+    .hero{ text-align:center; }
+    .hero h1{ font:900 32px/1.1 var(--font-display); margin:0 0 12px; }
+    .hero p{ margin:0 auto; max-width:60ch; color:var(--muted); }
+    .grid{ display:grid; grid-template-columns: repeat(auto-fill, minmax(240px,1fr)); gap:16px; }
+    .card{ border:1px solid var(--border); border-radius:16px; padding:18px; background:var(--panel); display:grid; gap:12px; }
+    .card img{ width:100%; border-radius:12px; background:var(--panel-2); }
+    .traits{ list-style:none; margin:0; padding:0; display:grid; gap:4px; font-size:12px; color:var(--muted); }
+    .footer{ text-align:center; color:var(--muted); font-size:13px; padding:32px 0 12px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="hero">
+      <h1>Classic Collector Grid</h1>
+      <p>Familiar gallery layout with balanced spacing, perfect for scanning frogs by rarity, species, and vibes.</p>
+    </header>
+
+    <section class="grid">
+      <article class="card">
+        <img src="../frog/1.png" alt="Frog 1" />
+        <h2>#0001 • Legendary</h2>
+        <ul class="traits">
+          <li>Frog: Classic Green</li>
+          <li>Trait: Golden Crown</li>
+          <li>Background: Deep Marsh</li>
+        </ul>
+      </article>
+      <article class="card">
+        <img src="../frog/2.png" alt="Frog 2" />
+        <h2>#0002 • Epic</h2>
+        <ul class="traits">
+          <li>Frog: Azure Ripple</li>
+          <li>Trait: Meteor Shades</li>
+          <li>Background: Sunset Fade</li>
+        </ul>
+      </article>
+      <article class="card">
+        <img src="../frog/3.png" alt="Frog 3" />
+        <h2>#0003 • Rare</h2>
+        <ul class="traits">
+          <li>Frog: Ember Tide</li>
+          <li>Trait: Orchid Bloom</li>
+          <li>Background: Twilight Mists</li>
+        </ul>
+      </article>
+    </section>
+
+    <footer class="footer">Classic layout preview • Placeholder content</footer>
+  </div>
+</body>
+</html>

--- a/layouts/layout-02-mosaic.html
+++ b/layouts/layout-02-mosaic.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Mosaic Layout</title>
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <style>
+    body{ background:linear-gradient(160deg,#08131f,#031820); color:#f3f8ff; font-family:var(--font-ui); }
+    .nav{ display:flex; justify-content:space-between; align-items:center; padding:24px 8vw; text-transform:uppercase; letter-spacing:.08em; font-size:12px; }
+    .nav a{ color:inherit; text-decoration:none; }
+    .stage{ display:grid; grid-template-columns:2fr 1fr; gap:32px; align-items:start; padding:0 8vw 8vw; }
+    .hero{ background:rgba(6,30,44,.65); border:1px solid rgba(255,255,255,.12); border-radius:28px; padding:40px; display:grid; gap:28px; backdrop-filter:blur(16px); }
+    .hero h1{ font:900 48px/1.05 var(--font-display); margin:0; }
+    .hero p{ margin:0; max-width:48ch; color:rgba(243,248,255,.75); font-size:15px; }
+    .hero .cta{ display:flex; gap:16px; }
+    .hero .cta button{ padding:12px 24px; border-radius:999px; border:none; font-weight:700; cursor:pointer; }
+    .hero .cta button:first-child{ background:#45d0ff; color:#021725; }
+    .hero .cta button:last-child{ background:transparent; color:#45d0ff; border:1px solid currentColor; }
+    .mosaic{ display:grid; gap:20px; grid-template-columns:repeat(2, minmax(0,1fr)); }
+    .tile{ position:relative; overflow:hidden; border-radius:22px; background:#112636; min-height:180px; }
+    .tile img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; opacity:.35; }
+    .tile h2{ position:absolute; bottom:18px; left:18px; margin:0; font:800 20px/1.1 var(--font-display); }
+    @media (max-width:960px){ .stage{ grid-template-columns:1fr; } .mosaic{ grid-template-columns:repeat(auto-fill,minmax(220px,1fr)); } }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <span>Fresh Frogs</span>
+    <div class="links"><a href="#">Collection</a> · <a href="#">Stake</a> · <a href="#">Pond</a></div>
+  </nav>
+
+  <div class="stage">
+    <section class="hero">
+      <h1>Mosaic Universe</h1>
+      <p>Layered hero with accent actions and a glassmorphism wrapper. Showcases a highlight reel of rare frogs alongside quick actions.</p>
+      <div class="cta">
+        <button type="button">Explore Frogs</button>
+        <button type="button">View Pond</button>
+      </div>
+    </section>
+
+    <aside class="mosaic">
+      <div class="tile"><img src="../frog/12.png" alt="Frog" /><h2>Mint Window</h2></div>
+      <div class="tile"><img src="../frog/204.png" alt="Frog" /><h2>Live Trades</h2></div>
+      <div class="tile"><img src="../frog/301.png" alt="Frog" /><h2>Top Stakers</h2></div>
+      <div class="tile"><img src="../frog/88.png" alt="Frog" /><h2>Featured Trait</h2></div>
+    </aside>
+  </div>
+</body>
+</html>

--- a/layouts/layout-03-deck.html
+++ b/layouts/layout-03-deck.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Deck Layout</title>
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <style>
+    body{ background:#040404; color:#f5f5f5; font-family:var(--font-ui); }
+    .wrap{ padding:60px 6vw; }
+    .title{ text-transform:uppercase; letter-spacing:.4em; font-size:13px; color:#777; }
+    h1{ margin:8px 0 40px; font:900 52px/1 var(--font-display); }
+    .deck{ position:relative; height:420px; }
+    .card{ position:absolute; top:0; width:320px; height:420px; padding:24px; border-radius:24px; background:#111; border:1px solid rgba(255,255,255,.08); display:grid; gap:16px; box-shadow:0 30px 80px rgba(0,0,0,.45); }
+    .card:nth-child(1){ left:0; transform:rotate(-6deg); }
+    .card:nth-child(2){ left:180px; transform:rotate(-2deg); }
+    .card:nth-child(3){ left:360px; transform:rotate(4deg); }
+    .card img{ width:100%; border-radius:18px; background:#1c1c1c; }
+    .card h2{ margin:0; font-size:22px; font-weight:800; }
+    .card p{ margin:0; font-size:14px; color:#aaa; }
+    .card footer{ font-size:12px; text-transform:uppercase; letter-spacing:.1em; color:#6df4a7; }
+    @media (max-width:1100px){ .deck{ height:auto; display:grid; gap:20px; } .card{ position:static; transform:none; width:auto; height:auto; } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="title">Fresh Frogs concept deck</div>
+    <h1>Layered Trading Card Fan-Out</h1>
+    <div class="deck">
+      <article class="card">
+        <img src="../frog/45.png" alt="Frog 45" />
+        <h2>Frog #45 — Neon Cipher</h2>
+        <p>A luminous cipher frog with holographic glyph overlays and a midnight mist backdrop.</p>
+        <footer>Mint slot: 1</footer>
+      </article>
+      <article class="card">
+        <img src="../frog/888.png" alt="Frog 888" />
+        <h2>Frog #888 — Crystal Tide</h2>
+        <p>Shimmering crystalline frog poised in a prismatic stream. Perfect for collectors chasing gleam.</p>
+        <footer>Mint slot: 2</footer>
+      </article>
+      <article class="card">
+        <img src="../frog/1024.png" alt="Frog 1024" />
+        <h2>Frog #1024 — Arcane Shade</h2>
+        <p>Shadow-cloaked frog with arcane runes, ideal for a dramatic landing page hero moment.</p>
+        <footer>Mint slot: 3</footer>
+      </article>
+    </div>
+  </div>
+</body>
+</html>

--- a/layouts/layout-04-minimal.html
+++ b/layouts/layout-04-minimal.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Minimal Layout</title>
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <style>
+    body{ background:#f3f5f7; color:#132025; font-family:var(--font-ui); }
+    header{ padding:48px 0 24px; text-align:center; }
+    header h1{ margin:0; font:900 44px/1 var(--font-display); }
+    header p{ margin:12px auto 0; max-width:72ch; color:#4f6670; }
+    main{ display:grid; gap:40px; max-width:900px; margin:0 auto; padding:0 20px 60px; }
+    .split{ display:grid; gap:24px; grid-template-columns: 1fr 1fr; }
+    .panel{ border-radius:18px; border:1px solid rgba(13,40,48,.1); background:#fff; padding:28px; box-shadow:0 18px 45px rgba(6,22,28,.08); }
+    .panel h2{ margin:0 0 14px; font-size:22px; }
+    .panel p{ margin:0 0 16px; color:#4f6670; }
+    .panel ul{ margin:0; padding:0; list-style:none; display:grid; gap:10px; font-size:14px; }
+    .panel ul li{ padding:12px; background:#f3f6f8; border-radius:12px; }
+    .panel ul li strong{ display:block; font-weight:700; color:#132025; }
+    .bar{ display:grid; gap:12px; }
+    .bar span{ display:block; height:8px; border-radius:999px; background:linear-gradient(90deg,#53c6ff,#82fbd3); }
+    @media (max-width:860px){ .split{ grid-template-columns:1fr; } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Minimal Stacking Layout</h1>
+    <p>Whitespace focused layout ideal for quick stats, collector overviews, and a calm presentation of the frog universe.</p>
+  </header>
+
+  <main>
+    <section class="split">
+      <article class="panel">
+        <h2>Live Mint Queue</h2>
+        <p>Highlight mint progress with simple gradient bars.</p>
+        <div class="bar"><span style="width:76%"></span></div>
+      </article>
+      <article class="panel">
+        <h2>Featured Collectors</h2>
+        <ul>
+          <li><strong>0x92A…4cd2</strong> Holding 37 frogs</li>
+          <li><strong>0x5BF…1109</strong> Holding 21 frogs</li>
+          <li><strong>0xE33…9a77</strong> Holding 18 frogs</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="panel">
+      <h2>Today in the Pond</h2>
+      <p>Short timeline modules showcase staking moves, trait reveals, and lore drops. Replace the placeholder copy with live activity feed data.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/layouts/layout-05-sidebar.html
+++ b/layouts/layout-05-sidebar.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Sidebar Layout</title>
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <style>
+    body{ margin:0; background:#0b121a; color:#e4f1ff; font-family:var(--font-ui); display:grid; grid-template-columns:280px 1fr; min-height:100vh; }
+    aside{ background:#050a11; padding:36px 28px; border-right:1px solid rgba(255,255,255,.05); display:grid; gap:24px; }
+    aside h1{ margin:0; font:900 28px/1 var(--font-display); }
+    aside nav{ display:grid; gap:12px; font-size:14px; }
+    aside nav a{ color:rgba(228,241,255,.75); text-decoration:none; padding:8px 12px; border-radius:10px; }
+    aside nav a.active{ background:linear-gradient(120deg,#2ea9ff,#86fccc); color:#031320; font-weight:700; }
+    main{ padding:48px 48px 64px; display:grid; gap:40px; }
+    .board{ display:grid; gap:20px; grid-template-columns:repeat(auto-fill,minmax(260px,1fr)); }
+    .card{ border-radius:20px; border:1px solid rgba(255,255,255,.06); background:rgba(9,24,36,.7); padding:20px; display:grid; gap:14px; }
+    .card img{ width:100%; border-radius:14px; background:#0f1f2c; }
+    .meta{ font-size:13px; color:rgba(228,241,255,.65); display:flex; justify-content:space-between; }
+    .meta span:first-child{ font-weight:700; color:#fff; }
+    @media (max-width:920px){ body{ grid-template-columns:1fr; } aside{ border-right:none; border-bottom:1px solid rgba(255,255,255,.05); grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); align-items:center; text-align:center; } aside nav{ grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); } }
+  </style>
+</head>
+<body>
+  <aside>
+    <h1>Fresh Frogs HQ</h1>
+    <nav>
+      <a href="#" class="active">Dashboard</a>
+      <a href="#">Collection</a>
+      <a href="#">Rarity</a>
+      <a href="#">Pond</a>
+      <a href="#">Activity</a>
+    </nav>
+    <div style="font-size:12px; color:rgba(228,241,255,.55);">Placeholder copy: show wallet status, quick stats, and mint timers.</div>
+  </aside>
+  <main>
+    <section>
+      <h2 style="margin:0 0 18px; font-size:26px;">Featured Frogs</h2>
+      <div class="board">
+        <article class="card">
+          <img src="../frog/120.png" alt="Frog 120" />
+          <div class="meta"><span>#0120</span><span>Legendary</span></div>
+        </article>
+        <article class="card">
+          <img src="../frog/740.png" alt="Frog 740" />
+          <div class="meta"><span>#0740</span><span>Epic</span></div>
+        </article>
+        <article class="card">
+          <img src="../frog/333.png" alt="Frog 333" />
+          <div class="meta"><span>#0333</span><span>Rare</span></div>
+        </article>
+        <article class="card">
+          <img src="../frog/908.png" alt="Frog 908" />
+          <div class="meta"><span>#0908</span><span>Uncommon</span></div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/layouts/layout-06-magazine.html
+++ b/layouts/layout-06-magazine.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Magazine Layout</title>
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <style>
+    body{ margin:0; background:#fef9f1; color:#1f1408; font-family:var(--font-ui); }
+    header{ padding:60px 10vw 40px; display:grid; gap:12px; }
+    header h1{ margin:0; font:900 64px/0.95 var(--font-display); letter-spacing:-.03em; }
+    header p{ margin:0; max-width:70ch; font-size:18px; }
+    .content{ display:grid; grid-template-columns:2fr 1fr; gap:36px; padding:0 10vw 80px; }
+    .lead{ background:#fff1d9; border-radius:30px; padding:36px; display:grid; gap:24px; box-shadow:0 30px 60px rgba(146,102,43,.18); }
+    .lead img{ width:100%; border-radius:26px; }
+    .lead h2{ margin:0; font:800 28px/1 var(--font-display); }
+    .lead p{ margin:0; font-size:16px; }
+    .side{ display:grid; gap:24px; }
+    .story{ background:#ffffff; border-radius:24px; padding:24px; box-shadow:0 20px 45px rgba(0,0,0,.08); }
+    .story h3{ margin:0 0 8px; font-size:20px; }
+    .story p{ margin:0; color:#624626; line-height:1.5; }
+    .story small{ display:block; margin-top:12px; text-transform:uppercase; letter-spacing:.18em; font-size:11px; color:#a17441; }
+    @media (max-width:1020px){ .content{ grid-template-columns:1fr; } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Fresh Frogs Weekly</h1>
+    <p>Magazine-style layout emphasising editorial storytelling around new mints, rare finds, and lore updates.</p>
+  </header>
+
+  <main class="content">
+    <article class="lead">
+      <img src="../frog/450.png" alt="Frog 450" />
+      <h2>Cover Story — The Aurora Chorus</h2>
+      <p>Placeholder article describing a legendary line of aurora frogs and the collectors who chase their cosmic glow.</p>
+    </article>
+
+    <aside class="side">
+      <div class="story">
+        <h3>Trait Spotlight</h3>
+        <p>Why the Echo Lily headpiece is seeing renewed demand among pond dwellers this season.</p>
+        <small>Section 01</small>
+      </div>
+      <div class="story">
+        <h3>Market Moves</h3>
+        <p>A sample snapshot of sales volume, staking shifts, and the hottest lily pad neighborhoods.</p>
+        <small>Section 02</small>
+      </div>
+      <div class="story">
+        <h3>Collector Interview</h3>
+        <p>Short Q&A excerpt with a fictional whale collector to illustrate editorial formatting.</p>
+        <small>Section 03</small>
+      </div>
+    </aside>
+  </main>
+</body>
+</html>

--- a/layouts/layout-07-glass.html
+++ b/layouts/layout-07-glass.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Glass Layout</title>
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <style>
+    body{ margin:0; min-height:100vh; background:url('../frog/1.png') center/cover fixed, radial-gradient(circle at top,#06203d,#02060b); color:#edfcff; font-family:var(--font-ui); }
+    .overlay{ backdrop-filter:blur(28px); background:linear-gradient(160deg,rgba(8,35,68,.6),rgba(3,10,20,.85)); min-height:100vh; }
+    header{ padding:48px 8vw 0; }
+    header h1{ margin:0; font:900 58px/0.95 var(--font-display); letter-spacing:-.02em; }
+    header p{ margin:14px 0 0; max-width:60ch; color:rgba(237,252,255,.7); }
+    .cards{ padding:48px 8vw 80px; display:grid; grid-template-columns:repeat(auto-fill,minmax(260px,1fr)); gap:26px; }
+    .card{ position:relative; padding:24px; border-radius:24px; border:1px solid rgba(255,255,255,.25); background:linear-gradient(140deg,rgba(73,208,255,.3),rgba(12,41,71,.85)); box-shadow:0 25px 80px rgba(0,0,0,.45); display:grid; gap:18px; }
+    .card::after{ content:""; position:absolute; inset:-1px; border-radius:inherit; border:1px solid rgba(255,255,255,.25); mix-blend-mode:screen; pointer-events:none; }
+    .card img{ width:100%; border-radius:18px; background:rgba(5,14,26,.8); }
+    .card h2{ margin:0; font-size:22px; font-weight:800; }
+    .card p{ margin:0; color:rgba(237,252,255,.8); font-size:14px; }
+  </style>
+</head>
+<body>
+  <div class="overlay">
+    <header>
+      <h1>Glass Pond Showcase</h1>
+      <p>Futuristic glassmorphism layout with glowing edges, ideal for a premium reveal of legendary frogs.</p>
+    </header>
+
+    <section class="cards">
+      <article class="card">
+        <img src="../frog/501.png" alt="Frog 501" />
+        <h2>Frog #501 — Glacier Pulse</h2>
+        <p>Placeholder description emphasising icy animation overlays and aurora-laced backgrounds.</p>
+      </article>
+      <article class="card">
+        <img src="../frog/640.png" alt="Frog 640" />
+        <h2>Frog #640 — Vapor Bloom</h2>
+        <p>Imagine a vapor trail effect swirling around the frog’s silhouette for a dynamic hover state.</p>
+      </article>
+      <article class="card">
+        <img src="../frog/777.png" alt="Frog 777" />
+        <h2>Frog #777 — Halo Drift</h2>
+        <p>Halo-style ring animation idea for future enhancement; placeholder copy for now.</p>
+      </article>
+    </section>
+  </div>
+</body>
+</html>

--- a/layouts/layout-08-terminal.html
+++ b/layouts/layout-08-terminal.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Terminal Layout</title>
+  <style>
+    :root{
+      color-scheme: dark;
+      --bg:#020403;
+      --panel:#04120a;
+      --text:#9cffd6;
+      --accent:#47ff9c;
+      --mono:'JetBrains Mono',SFMono-Regular,Menlo,Consolas,monospace;
+    }
+    @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap');
+    body{ margin:0; background:var(--bg); color:var(--text); font-family:var(--mono); min-height:100vh; display:grid; place-items:center; padding:40px; }
+    .terminal{ width:min(900px,100%); border:2px solid var(--accent); border-radius:18px; box-shadow:0 0 32px rgba(71,255,156,.25); overflow:hidden; background:var(--panel); }
+    .terminal header{ display:flex; align-items:center; gap:8px; padding:12px 16px; border-bottom:2px solid var(--accent); }
+    .terminal header span{ width:12px; height:12px; border-radius:50%; background:var(--accent); opacity:.45; }
+    .terminal header h1{ font-size:16px; margin:0 auto 0 0; }
+    pre{ margin:0; padding:24px; font-size:14px; line-height:1.6; white-space:pre-wrap; }
+    .cursor{ animation:blink 1.1s steps(1) infinite; }
+    @keyframes blink{ 50%{ opacity:0; } }
+  </style>
+</head>
+<body>
+  <div class="terminal">
+    <header>
+      <span></span><span></span><span></span>
+      <h1>freshfrogs ~ layout showcase</h1>
+    </header>
+    <pre>
+$ connect pond
+> handshake complete
+
+$ query frogs --limit 3
+> #0007 : SpecialFrog / Hyper Bloom / Lagoon Fade
+> #0420 : Frog / Vapor Trails / Midnight Current
+> #1984 : Frog / Synthwave Crown / Neon Grid
+
+$ describe layout
+> Terminal themed presentation for data-heavy dashboards.
+> Highlight rarity, staking stats, or sales feeds in a nostalgic shell.
+
+$ _<span class="cursor">█</span>
+    </pre>
+  </div>
+</body>
+</html>

--- a/layouts/layout-09-masonry.html
+++ b/layouts/layout-09-masonry.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Masonry Layout</title>
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <style>
+    body{ margin:0; background:#101012; color:#f4f4f4; font-family:var(--font-ui); }
+    header{ padding:40px 6vw 20px; }
+    header h1{ margin:0; font:900 40px/1 var(--font-display); }
+    header p{ margin:8px 0 0; max-width:60ch; color:#a3a3a8; }
+    .masonry{ column-count:3; column-gap:20px; padding:0 6vw 80px; }
+    .tile{ break-inside:avoid; margin:0 0 20px; background:#1b1b1f; border-radius:18px; overflow:hidden; box-shadow:0 22px 45px rgba(0,0,0,.35); }
+    .tile img{ width:100%; display:block; }
+    .tile section{ padding:18px; display:grid; gap:10px; }
+    .tile h2{ margin:0; font-size:20px; }
+    .tile p{ margin:0; color:#c0c0c5; font-size:14px; }
+    @media (max-width:1100px){ .masonry{ column-count:2; } }
+    @media (max-width:720px){ .masonry{ column-count:1; } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Freeform Masonry Grid</h1>
+    <p>Staggered tiles emphasise large frog art, lore blurbs, and quick stats without a rigid grid.</p>
+  </header>
+  <main class="masonry">
+    <article class="tile">
+      <img src="../frog/210.png" alt="Frog 210" />
+      <section>
+        <h2>Frog #210</h2>
+        <p>Legendary mystic with swirling constellations. Perfect for feature hero slots.</p>
+      </section>
+    </article>
+    <article class="tile">
+      <img src="../frog/678.png" alt="Frog 678" />
+      <section>
+        <h2>Frog #678</h2>
+        <p>Epic tidal variant with foamy crest details. Consider parallax scroll pairings.</p>
+      </section>
+    </article>
+    <article class="tile">
+      <img src="../frog/999.png" alt="Frog 999" />
+      <section>
+        <h2>Frog #999</h2>
+        <p>Mythic frog rumored to unlock pond secrets. Reserve for special reveals.</p>
+      </section>
+    </article>
+    <article class="tile">
+      <img src="../frog/58.png" alt="Frog 58" />
+      <section>
+        <h2>Frog #058</h2>
+        <p>Uncommon but charismatic lily pad ambassador. Good for onboarding flows.</p>
+      </section>
+    </article>
+  </main>
+</body>
+</html>

--- a/layouts/layout-10-spotlight.html
+++ b/layouts/layout-10-spotlight.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Spotlight Layout</title>
+  <link rel="stylesheet" href="../assets/css/styles.css" />
+  <style>
+    body{ background:#060708; color:#fefbff; font-family:var(--font-ui); margin:0; }
+    .wrap{ display:grid; gap:40px; padding:60px 10vw 80px; }
+    .spotlight{ display:grid; gap:24px; grid-template-columns:1.2fr 1fr; align-items:center; }
+    .spotlight figure{ margin:0; position:relative; }
+    .spotlight figure::before{ content:""; position:absolute; inset:-14%; border-radius:50%; background:radial-gradient(circle,#ffb34755,#ff5d9355,#4f00ff22); filter:blur(20px); }
+    .spotlight img{ position:relative; width:100%; border-radius:24px; box-shadow:0 30px 80px rgba(79,0,255,.35); }
+    .spotlight article{ display:grid; gap:16px; }
+    .spotlight h1{ margin:0; font:900 56px/0.95 var(--font-display); letter-spacing:-.02em; }
+    .spotlight p{ margin:0; max-width:60ch; color:rgba(254,251,255,.72); }
+    .stats{ display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:20px; }
+    .stats .card{ border-radius:20px; padding:20px; background:#0c0f18; border:1px solid rgba(255,255,255,.08); display:grid; gap:8px; }
+    .stats .card span{ font-size:12px; color:rgba(254,251,255,.5); text-transform:uppercase; letter-spacing:.2em; }
+    .stats .card strong{ font-size:26px; }
+    .timeline{ border-left:2px solid rgba(255,255,255,.12); padding-left:28px; display:grid; gap:24px; }
+    .timeline article{ position:relative; }
+    .timeline article::before{ content:""; position:absolute; left:-39px; top:2px; width:16px; height:16px; border-radius:50%; background:#ff8fb8; box-shadow:0 0 0 4px rgba(255,143,184,.25); }
+    .timeline h3{ margin:0 0 6px; font-size:18px; }
+    .timeline p{ margin:0; color:rgba(254,251,255,.65); font-size:14px; }
+    @media (max-width:980px){ .spotlight{ grid-template-columns:1fr; text-align:center; } .spotlight article{ justify-items:center; } .spotlight figure::before{ inset:-20%; } }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <section class="spotlight">
+      <figure>
+        <img src="../frog/1111.png" alt="Frog 1111" />
+      </figure>
+      <article>
+        <h1>Legendary Spotlight</h1>
+        <p>Hero spotlight layout for an individual frog drop. Combine bold headlines with glowy backgrounds for dramatic reveals.</p>
+      </article>
+    </section>
+
+    <section class="stats">
+      <div class="card"><span>Minted</span><strong>4,040</strong></div>
+      <div class="card"><span>Staked</span><strong>2,980</strong></div>
+      <div class="card"><span>Flyz earned</span><strong>12.4M</strong></div>
+      <div class="card"><span>Unique holders</span><strong>1,780</strong></div>
+    </section>
+
+    <section class="timeline">
+      <article>
+        <h3>Day 1 — Launch</h3>
+        <p>Introduce the frog collection with a bold hero section and call to action.</p>
+      </article>
+      <article>
+        <h3>Day 7 — Staking opens</h3>
+        <p>Highlight staking timeline entries and reward tiers in this vertical flow.</p>
+      </article>
+      <article>
+        <h3>Day 30 — Pond party</h3>
+        <p>Use timeline beats to share lore events, community updates, and trait spotlights.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/pond.html
+++ b/pond.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en" data-theme="t1">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fresh Frogs — Staking Pond</title>
+
+  <link rel="stylesheet" href="assets/css/styles.css" />
+
+  <style>
+    .pg-wrap{ padding:20px; }
+    img{ image-rendering: pixelated; image-rendering: crisp-edges; }
+    .pg-card{ padding:14px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
+    .pg-card-head{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
+    .pg-card-head h3{ margin:0; font-weight:800; font-size:16px; }
+    .pg-muted{ color:var(--muted); font-size:13px; }
+
+    :root{ --panel-width: 1100px; }
+    .center-wrap{ display:grid; gap:16px; justify-items:center; }
+    .centered-card{ width: min(var(--panel-width), 100%); }
+
+    .frog-hero{ margin:28px auto 10px; width: min(var(--panel-width), 100%); }
+    .frog-title{ margin:0 0 6px 0; font:900 28px/1.15 'Space Grotesk', var(--font-ui); letter-spacing:-.01em; text-align:center; }
+    .frog-strip{ display:flex; gap:12px; align-items:center; justify-content:center; overflow:hidden; padding:0; }
+    .frog-strip .tile{ flex:0 0 auto; width:64px; height:64px; border-radius:10px; }
+    .frog-strip img{ width:64px; height:64px; object-fit:contain; }
+    .frog-strip .tile.hide{ display:none !important; }
+
+    .controls{ display:flex; flex-wrap:wrap; gap:10px; align-items:center; margin:12px 0 16px; }
+    .controls .btn{ padding:8px 14px; font-size:13px; }
+    .controls .search{ display:flex; gap:8px; align-items:center; }
+    .controls input{ width:160px; padding:8px 10px; border-radius:10px; border:1px solid var(--border); background:transparent; color:inherit; font-family:var(--font-ui); }
+    .controls input:focus{ outline:none; box-shadow:var(--focus); }
+    .sr-only{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0; }
+
+    #rarityGrid{ display:grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap:12px; }
+    #rarityGrid .pg-muted{ padding:8px; }
+    #btnMore{ margin:20px auto 0; display:block; }
+  </style>
+</head>
+<body>
+  <div class="pg-wrap container">
+    <div class="center-wrap">
+      <section class="frog-hero">
+        <h1 class="frog-title">Staking Pond</h1>
+        <p class="pg-muted" style="text-align:center; max-width:70ch; margin:8px auto 16px;">
+          Browse every frog currently soaking in the pond. Sort by rarity rank or how long they have been staked,
+          then jump straight to any token ID for a closer look.
+        </p>
+        <div class="frog-strip">
+          <div class="tile"><img src="frog/12.png"  alt="12"></div>
+          <div class="tile"><img src="frog/88.png"  alt="88"></div>
+          <div class="tile"><img src="frog/415.png" alt="415"></div>
+          <div class="tile"><img src="frog/777.png" alt="777"></div>
+          <div class="tile"><img src="frog/256.png" alt="256"></div>
+          <div class="tile"><img src="frog/999.png" alt="999"></div>
+        </div>
+      </section>
+    </div>
+
+    <section class="pg-card centered-card" id="pondListWrap">
+      <div class="pg-card-head">
+        <h3>Currently staked frogs</h3>
+        <div class="pg-muted" id="pondCount">Loading…</div>
+      </div>
+
+      <div class="controls">
+        <button id="btnSortRank" class="btn btn-ghost btn-sm">Sort: Rank ↑</button>
+        <button id="btnSortScore" class="btn btn-ghost btn-sm">Sort: Time ↑</button>
+        <div class="search">
+          <label class="sr-only" for="raritySearchId">Find frog ID</label>
+          <input id="raritySearchId" type="number" min="1" placeholder="Find frog ID…" />
+          <button id="btnGo" class="btn btn-solid btn-sm">Go</button>
+        </div>
+        <button id="btnThemeCycle" class="btn btn-ghost btn-sm" style="margin-left:auto;">Theme: Classic</button>
+      </div>
+
+      <div id="rarityGrid">
+        <div class="pg-muted">Loading pond…</div>
+      </div>
+
+      <button id="btnMore" class="btn btn-outline btn-sm" style="display:none;">Load more</button>
+    </section>
+  </div>
+
+  <script>
+    (function(){
+      var CFG = window.FF_CFG || {};
+      var ROOT = String(CFG.SOURCE_PATH || '').replace(/\/+$/,'');
+      var TOTAL = Number(CFG.TOTAL_SUPPLY || 4040);
+      function shuffle(count, max){
+        var pool = [];
+        for (var i=1;i<=max;i++) pool.push(i);
+        for (var j=pool.length-1;j>0;j--){
+          var k = Math.floor(Math.random()*(j+1));
+          var t = pool[j]; pool[j]=pool[k]; pool[k]=t;
+        }
+        return pool.slice(0,count);
+      }
+      function randomizeStrip(){
+        var strip = document.querySelector('.frog-strip'); if(!strip) return;
+        var imgs = Array.prototype.slice.call(strip.querySelectorAll('img'));
+        if(!imgs.length) return;
+        var ids = shuffle(imgs.length, TOTAL);
+        imgs.forEach(function(img, idx){
+          var id = ids[idx];
+          img.src = ROOT + '/frog/' + id + '.png';
+          img.alt = 'Frog ' + id;
+        });
+        layoutStrip();
+      }
+      function layoutStrip(){
+        var strip = document.querySelector('.frog-strip'); if(!strip) return;
+        var tiles = Array.prototype.slice.call(strip.querySelectorAll('.tile'));
+        var gap = parseFloat(getComputedStyle(strip).gap || 12) || 12;
+        var tileW = 64;
+        var inner = strip.clientWidth;
+        var count = Math.max(1, Math.floor((inner + gap) / (tileW + gap)));
+        tiles.forEach(function(tile, i){ tile.classList.toggle('hide', i >= count); });
+      }
+      window.addEventListener('resize', layoutStrip);
+      if(document.readyState === 'loading') document.addEventListener('DOMContentLoaded', randomizeStrip);
+      else randomizeStrip();
+    })();
+  </script>
+
+  <script>
+    window.FF_RARITY_PAGE_CONFIG = {
+      stakedOnly: true,
+      defaultSortMode: 'rank',
+      secondSortMode: 'time',
+      autoLoadMin: 9
+    };
+  </script>
+
+  <script src="https://cdn.jsdelivr.net/npm/web3@1.10.4/dist/web3.min.js"></script>
+  <script src="assets/js/config.js"></script>
+  <script src="assets/js/utils.js"></script>
+  <script src="assets/js/rarity.js"></script>
+  <script src="assets/js/modal.js"></script>
+  <script src="assets/abi/collection_abi.js"></script>
+  <script src="assets/abi/controller_abi.js"></script>
+  <script src="assets/js/staking-adapter.js"></script>
+  <script src="assets/js/frog-renderer.js"></script>
+  <script src="assets/js/frog-cards.js" defer></script>
+  <script src="assets/js/topbar.js"></script>
+  <script src="assets/js/rarity-page.js"></script>
+  <script>
+    (function(){
+      var grid = document.getElementById('rarityGrid');
+      var countEl = document.getElementById('pondCount');
+      if(!grid || !countEl) return;
+      function update(){
+        var cards = grid.querySelectorAll('.frog-card');
+        if(cards.length){
+          countEl.textContent = cards.length + ' frogs loaded';
+        }
+      }
+      var obs = new MutationObserver(function(){ update(); });
+      obs.observe(grid, { childList:true, subtree:true });
+      update();
+    })();
+  </script>
+</body>
+</html>

--- a/rarity.html
+++ b/rarity.html
@@ -3,153 +3,251 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>freshfrogs — Rarity</title>
+  <title>Fresh Frogs — Rarity Rankings</title>
 
   <link rel="stylesheet" href="assets/css/styles.css" />
 
   <style>
-    /* mirror collection.html base feel */
+    /* Page shell to match collection */
     .pg-wrap{ padding:20px; }
     img{ image-rendering: pixelated; image-rendering: crisp-edges; }
-
     .pg-card{ padding:14px; border:1px solid var(--border); border-radius:12px; background:var(--panel); }
     .pg-card-head{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
     .pg-card-head h3{ margin:0; font-weight:800; font-size:16px; }
     .pg-muted{ color:var(--muted); font-size:13px; }
 
-    /* Hero (identical structure so topbar.js pills work) */
-    .frog-hero{ margin:28px auto 38px; max-width:1100px; }
+    /* Centered width like collection */
+    :root{ --panel-width: 1100px; }
+    .center-wrap{ display:grid; gap:16px; justify-items:center; }
+    .centered-card{ width: min(var(--panel-width), 100%); }
+
+    /* Hero */
+    .frog-hero{ margin:28px auto 10px; width: min(var(--panel-width), 100%); }
     .frog-title{ margin:0 0 6px 0; font:900 28px/1.15 'Space Grotesk', var(--font-ui); letter-spacing:-.01em; text-align:center; }
     .frog-strip{ display:flex; gap:12px; align-items:center; justify-content:center; overflow:hidden; padding:0; }
     .frog-strip .tile{ flex:0 0 auto; width:64px; height:64px; border-radius:10px; }
     .frog-strip .tile.hide{ display:none !important; }
     .frog-strip img{ width:64px; height:64px; object-fit:contain; }
-    @media (max-width:520px){ .frog-hero{ margin:22px auto 30px; } .frog-strip{ gap:10px; } }
 
-    /* Single main panel with the grid */
-    .page-grid{ max-width:1100px; margin:0 auto; display:grid; gap:16px; grid-template-columns: 1fr; }
+    /* Grid area for frog-cards (reuses your .frog-card styles from styles.css) */
+    #rarityGrid{ display:grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap:12px; }
+    #rarityGrid.scrolling{ overflow:auto; -webkit-overflow-scrolling:touch; padding-right:4px; max-height: 70vh; }
+    @media (hover:hover){
+      #rarityGrid.scrolling::-webkit-scrollbar{ width:8px; }
+      #rarityGrid.scrolling::-webkit-scrollbar-thumb{ background: color-mix(in srgb,var(--muted) 35%, transparent); border-radius:8px; }
+    }
 
-    /* Use the same card styles defined in collection.html */
-    .frog-card{ border:1px solid var(--border); background:var(--panel); border-radius:14px; padding:12px;
-      display:grid; grid-template-columns:auto 1fr; column-gap:12px; row-gap:6px; align-items:start; color:inherit; }
+    /* Force 128×128 thumbs on these cards */
     .frog-card .thumb{
-      width:128px;height:128px;border-radius:12px;background:var(--panel-2);object-fit:contain;grid-row: span 3;
-      box-shadow: inset 0 0 0 1px rgba(255,255,255,.06), 0 6px 12px rgba(0,0,0,.25);
-    }
-    .title{ margin:0; font-weight:900; font-size:18px; letter-spacing:-.01em; display:flex; align-items:center; gap:8px; }
-    .pill{ display:inline-block; padding:3px 10px; border-radius:999px; background: color-mix(in srgb, var(--panel) 85%, transparent); border:1px solid var(--border); font-size:12px; }
-    .meta{ color:var(--muted); font-size:12px; }
-    .actions{ grid-column:1 / -1; display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
-    .btn{
-      font-family: var(--font-ui);
-      border:1px solid var(--border);
-      background:transparent;
-      color:inherit;
-      border-radius:8px;
-      padding:6px 10px;
-      font-weight:700;
-      font-size:12px;
-      line-height:1;
-      display:inline-flex; align-items:center; gap:6px;
-      text-decoration:none; letter-spacing:.01em;
-      transition: background .15s ease, border-color .15s ease, color .15s ease, transform .05s ease;
-    }
-    .btn:active{ transform: translateY(1px); }
-    .btn-outline-gray{ border-color: color-mix(in srgb, #9ca3af 70%, var(--border)); color: color-mix(in srgb, #ffffff 65%, #9ca3af); }
-    .btn:hover{
-      background: color-mix(in srgb, #22c55e 14%, var(--panel));
-      border-color: color-mix(in srgb, #22c55e 80%, var(--border));
-      color: color-mix(in srgb, #ffffff 85%, #22c55e);
+      width:128px; height:128px; min-width:128px; min-height:128px;
+      border-radius:10px; object-fit:contain; background:var(--panel-2);
     }
 
-    /* Grid */
-    #rarityGrid{ display:grid; gap:10px; grid-template-columns: 1fr; }
-    @media (min-width:720px){ #rarityGrid{ grid-template-columns: 1fr 1fr; } }
-    @media (min-width:1024px){ #rarityGrid{ grid-template-columns: 1fr 1fr 1fr; } }
+    /* Rank pill color grades (additive to your .pill) */
+    .pill.rk-legendary{ color:#f59e0b; border-color: color-mix(in srgb,#f59e0b 70%, var(--border)); }
+    .pill.rk-epic{ color:#a855f7; border-color: color-mix(in srgb,#a855f7 70%, var(--border)); }
+    .pill.rk-rare{ color:#38bdf8; border-color: color-mix(in srgb,#38bdf8 70%, var(--border)); }
 
-    /* Rank badge for image (optional; your card renderer can also inject this) */
-    .rank-badge{
-      position:absolute; top:8px; left:8px;
-      background:var(--ink,#0c0c0f); color:var(--fg,#eaeaea);
-      border:1px solid var(--border,#2a2a2f); border-radius:999px; padding:4px 10px; font-size:12px;
-      letter-spacing:.2px; opacity:.96;
-    }
-    .img-wrap{ position:relative; }
+    /* Attributes list */
+    .attr-bullets{ list-style:disc; margin:6px 0 0 18px; padding:0; }
+    .attr-bullets li{ font-size:12px; margin:2px 0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
   </style>
 </head>
 <body>
   <div class="pg-wrap container">
-    <!-- HERO (keep identical so topbar pills render) -->
-    <section class="frog-hero">
-      <h1 class="frog-title">freshfrogs.github.io</h1>
-      <div class="frog-strip">
-        <div class="tile"><img src="frog/12.png"  alt="12"></div>
-        <div class="tile"><img src="frog/77.png"  alt="77"></div>
-        <div class="tile"><img src="frog/404.png" alt="404"></div>
-        <div class="tile"><img src="frog/256.png" alt="256"></div>
-        <div class="tile"><img src="frog/999.png" alt="999"></div>
-        <div class="tile"><img src="frog/1.png"   alt="1"></div>
-      </div>
-    </section>
-    <div id="ffTopbarMount"></div>
-
-    <div class="page-grid">
-      <section class="pg-card">
-        <div class="pg-card-head">
-          <h3>Rarity Rankings</h3>
-          <div style="display:flex;gap:8px;flex-wrap:wrap;">
-            <button id="btnSortRank"  class="btn btn-outline-gray">Sort: Rank ↑</button>
-            <button id="btnSortScore" class="btn btn-outline-gray">Sort: Score ↓</button>
-            <input id="raritySearchId" type="number" min="1" placeholder="Find Frog ID…" style="width:140px; padding:6px 10px; border:1px solid var(--border); border-radius:8px; background:var(--panel-2); color:inherit;">
-            <button id="btnGo" class="btn btn-outline-gray">Go</button>
-          </div>
-        </div>
-
-        <div id="rarityGrid">
-          <div class="pg-muted">Loading rarity…</div>
-        </div>
-
-        <div style="display:grid; place-items:center; margin-top:10px;">
-          <button id="btnMore" class="btn btn-outline-gray" style="display:none;">Load More</button>
+    <div class="center-wrap">
+      <!-- HERO -->
+      <section class="frog-hero">
+        <h1 class="frog-title">Rarity Rankings</h1>
+        <div class="frog-strip">
+          <div class="tile"><img src="frog/12.png"  alt="12"></div>
+          <div class="tile"><img src="frog/77.png"  alt="77"></div>
+          <div class="tile"><img src="frog/404.png" alt="404"></div>
+          <div class="tile"><img src="frog/256.png" alt="256"></div>
+          <div class="tile"><img src="frog/999.png" alt="999"></div>
+          <div class="tile"><img src="frog/1.png"   alt="1"></div>
         </div>
       </section>
     </div>
+
+    <!-- Rankings panel -->
+    <section class="pg-card centered-card" style="margin-top:10px">
+      <div class="pg-card-head">
+        <h3>All Frogs by Rarity</h3>
+        <div class="pg-muted" id="rankCount">Loading…</div>
+      </div>
+
+      <div id="rarityGrid" class="scrolling" aria-live="polite">
+        <div class="pg-muted" style="padding:8px">Loading rankings…</div>
+      </div>
+    </section>
   </div>
 
+  <!-- Shared libs (same family as collection.html) -->
+  <script src="assets/js/config.js"></script>
+  <script src="assets/js/utils.js"></script>
+  <script src="assets/js/rarity.js"></script>
+  <script src="assets/js/topbar.js"></script>
+
   <script>
-    /* keep hero strip behavior the same */
+  (function(){
+    'use strict';
+
+    var CFG = window.FF_CFG || {};
+    var ROOT = String(CFG.SOURCE_PATH || '').replace(/\/+$/,'');
+    var RANKS_JSON = CFG.JSON_PATH || 'assets/freshfrogs_rarity_rankings.json';
+
+    var GRID = document.getElementById('rarityGrid');
+    var COUNT = document.getElementById('rankCount');
+
+    var PAGE = 36;
+    var cursor = 0;
+    var rows = [];
+    var observer = null;
+
+    function imgFor(id){ return ROOT + '/frog/' + id + '.png'; }
+    function jsonFor(id){ return ROOT + '/frog/json/' + id + '.json'; }
+
+    function tierFor(rank){
+      var T = (CFG.RARITY_TIERS) || { legendary: 50, epic: 250, rare: 800 };
+      if (typeof rank !== 'number' || !isFinite(rank)) return 'common';
+      if (rank <= T.legendary) return 'legendary';
+      if (rank <= T.epic) return 'epic';
+      if (rank <= T.rare) return 'rare';
+      return 'common';
+    }
+
+    function attrsHTML(attrs, max){
+      if (!Array.isArray(attrs)||!attrs.length) return '';
+      var out=[], n=0;
+      for (var i=0;i<attrs.length;i++){
+        var a=attrs[i]||{}, k=a.key||a.trait_type||a.traitType||a.type||'', v=(a.value!=null?a.value:a.trait_value);
+        if (!k || v==null) continue;
+        out.push('<li><b>'+String(k)+':</b> '+String(v)+'</li>');
+        if (++n>= (max||4)) break;
+      }
+      return out.length ? '<ul class="attr-bullets">'+out.join('')+'</ul>' : '';
+    }
+
+    function cardHTML(id, rank){
+      var tier = tierFor(rank);
+      var pillCls = tier==='legendary'?'rk-legendary':tier==='epic'?'rk-epic':tier==='rare'?'rk-rare':'';
+      var rankPill = '<span class="pill '+pillCls+'">Rank #'+rank+'</span>';
+
+      return ''+
+      '<article class="frog-card" data-token-id="'+id+'">'+
+        '<img class="thumb" src="'+imgFor(id)+'" alt="'+id+'">'+
+        '<h4 class="title">Frog #'+id+' '+rankPill+'</h4>'+
+      '</article>';
+    }
+
+    function appendNext(){
+      if (cursor >= rows.length) return;
+      var end = Math.min(rows.length, cursor + PAGE);
+      var frag = document.createDocumentFragment();
+
+      for (var i=cursor; i<end; i++){
+        (function(row){
+          var holder = document.createElement('div');
+          holder.innerHTML = cardHTML(row.id, row.ranking);
+          var el = holder.firstChild;
+          frag.appendChild(el);
+
+          // lazy load a few attributes per card (non-blocking)
+          fetch(jsonFor(row.id)).then(function(r){ return r.ok ? r.json() : null; }).then(function(j){
+            if (!j) return;
+            var attrs = Array.isArray(j.attributes) ? j.attributes : [];
+            var html = attrsHTML(attrs, 4);
+            if (!html) return;
+            var title = el.querySelector('.title');
+            title.insertAdjacentHTML('afterend', html);
+          }).catch(function(){});
+        })(rows[i]);
+      }
+      GRID.appendChild(frag);
+      cursor = end;
+
+      if (cursor >= rows.length && observer){
+        observer.disconnect();
+      }
+    }
+
+    function setupInfinite(){
+      var sentinel = document.createElement('div');
+      sentinel.style.height = '1px';
+      GRID.appendChild(sentinel);
+
+      observer = new IntersectionObserver(function(es){
+        if (es[0].isIntersecting) appendNext();
+      }, { root: GRID, rootMargin: '240px', threshold: 0.01 });
+
+      observer.observe(sentinel);
+    }
+
+    function loadJSON(path){
+      return fetch(path).then(function(r){ if(!r.ok) throw new Error('HTTP '+r.status); return r.json(); });
+    }
+
+    function normalizeRanks(raw){
+      var out=[];
+      if (Array.isArray(raw)){
+        for (var i=0;i<raw.length;i++){
+          var it = raw[i]||{};
+          var id = Number(it.id); var rk = Number(it.ranking!=null?it.ranking:it.rank);
+          if (isFinite(id) && isFinite(rk)) out.push({id:id, ranking:rk});
+        }
+      }else if (raw && typeof raw === 'object'){
+        for (var k in raw){ if (!raw.hasOwnProperty(k)) continue;
+          var id2 = Number(k); var rk2 = Number(raw[k]);
+          if (isFinite(id2) && isFinite(rk2)) out.push({id:id2, ranking:rk2});
+        }
+      }
+      out.sort(function(a,b){ return a.ranking - b.ranking || a.id - b.id; });
+      return out;
+    }
+
+    /* Keep whole 64px tiles only (hero strip) */
     function layoutFrogStrip(){
       var strip = document.querySelector('.frog-strip'); if(!strip) return;
-      var tiles = Array.prototype.slice.call(strip.querySelectorAll('.tile'));
-      var styles = window.getComputedStyle(strip);
-      var gap = parseFloat(styles.gap || 12) || 12;
+      var tiles = Array.from(strip.querySelectorAll('.tile'));
+      var gap = parseFloat(getComputedStyle(strip).gap || 12) || 12;
       var tileW = 64, innerW = strip.clientWidth;
       var count = Math.max(1, Math.floor((innerW + gap) / (tileW + gap)));
       tiles.forEach(function(t,i){ t.classList.toggle('hide', i >= count); });
     }
     window.addEventListener('resize', layoutFrogStrip);
-    document.addEventListener('DOMContentLoaded', layoutFrogStrip);
+
+    (function init(){
+      // Randomize hero strip
+      (function randomizeStrip(){
+        var TOTAL = Number((window.FF_CFG||{}).TOTAL_SUPPLY || 4040);
+        var strip = document.querySelector('.frog-strip'); if (!strip) return;
+        var imgs = Array.from(strip.querySelectorAll('.tile img')); if (!imgs.length) return;
+        var pool = Array.from({length:TOTAL}, function(_,i){ return i+1; });
+        for (var i=pool.length-1; i>0; i--){ var j=(Math.random()* (i+1))|0; var t=pool[i]; pool[i]=pool[j]; pool[j]=t; }
+        imgs.forEach(function(img, idx){
+          var id = pool[idx];
+          img.src = ROOT + '/frog/' + id + '.png';
+          img.alt = String(id);
+        });
+        layoutFrogStrip();
+      })();
+
+      // Load rankings → render incrementally
+      loadJSON(RANKS_JSON).then(normalizeRanks).then(function(arr){
+        rows = arr;
+        COUNT.textContent = (rows.length ? rows.length : 0) + ' frogs';
+        GRID.innerHTML = '';
+        appendNext();
+        setupInfinite();
+      }).catch(function(err){
+        console.warn('[rarity] failed', err);
+        GRID.innerHTML = '<div class="pg-muted" style="padding:8px">Failed to load rarity.</div>';
+        COUNT.textContent = '—';
+      });
+    })();
+
+  })();
   </script>
-
-  <!-- match your collection.html script stack/order (only what we need here) -->
-  <script src="https://cdn.jsdelivr.net/npm/web3@1.10.4/dist/web3.min.js"></script>
-  <script src="assets/js/config.js"></script>
-  <script src="assets/js/utils.js"></script>
-  <script src="assets/js/rarity.js"></script>
-  <script src="assets/js/modal.js"></script>
-
-  <!-- ABIs (some renderers or links reference addresses) -->
-  <script src="assets/abi/collection_abi.js"></script>
-  <script src="assets/abi/controller_abi.js"></script>
-
-  <!-- Card + renderer (same as dashboard) -->
-  <script src="assets/js/frog-renderer.js"></script>
-  <script src="assets/js/frog-cards.js" defer></script>
-
-  <!-- Top bar pills -->
-  <script src="assets/js/topbar.js"></script>
-
-  <!-- Rarity page glue -->
-  <script src="assets/js/rarity-page.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore the classic theme and markup across the main pages so the site returns to the earlier layout
- align the shared scripts with the classic DOM structure for collection, rarity, and pond views
- add a layouts/ directory containing ten placeholder layout concepts for future experimentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db79b842988331a0be89ddd6adef49